### PR TITLE
Added a component for field office links

### DIFF
--- a/src/components/call/Call.test.tsx
+++ b/src/components/call/Call.test.tsx
@@ -11,7 +11,6 @@ test('Call component should be rendered if passed a valid object', () => {
     currentIssueId: 'test1',
     contactIndexes: ['test1', 'test2'],
     completedIssueIds: ['test1', 'test2'],
-    showFieldOfficeNumbers: false
   };
 
   const onSubmitOutcome = jest.fn();

--- a/src/components/call/Call.tsx
+++ b/src/components/call/Call.tsx
@@ -70,8 +70,8 @@ export class Call extends React.Component<Props, State> {
         <header className="call__header">
           <h2 className="call__title">{this.state.issue.name}</h2>
           <div className="call__reason">
-            {this.state.issue.reason.split('\n').map(line => 
-              <p>{line}</p>
+            {this.state.issue.reason.split('\n').map((line, index) => 
+              <p key={index}>{line}</p>
             )}
           </div>
         </header>

--- a/src/components/call/Call.tsx
+++ b/src/components/call/Call.tsx
@@ -70,9 +70,9 @@ export class Call extends React.Component<Props, State> {
         <header className="call__header">
           <h2 className="call__title">{this.state.issue.name}</h2>
           <div className="call__reason">
-            {/* TODO: Split up script lines like this:
-             this.props.selectedIssue.reason.split('\n').map((line) => scriptLine(line, state, prev, send)) */}
-            {this.state.issue.reason}
+            {this.state.issue.reason.split('\n').map(line => 
+              <p>{line}</p>
+            )}
           </div>
         </header>
         {this.props.splitDistrict ?

--- a/src/components/call/ContactDetails.tsx
+++ b/src/components/call/ContactDetails.tsx
@@ -3,6 +3,7 @@ import { TranslationFunction } from 'i18next';
 import { translate } from 'react-i18next';
 import { Issue, Contact, DefaultContact } from '../../common/model';
 import { ContactOffices } from './index';
+import { makePhoneLink } from '../shared/jsxUtils';
 
 interface Props {
   readonly currentIssue: Issue;
@@ -35,16 +36,6 @@ const ContactDetails: React.StatelessComponent<Props> = ({ currentIssue, contact
         <p className="call__contact__reason">{contact.reason}</p>
       </div>
     );
-  }
-};
-
-const makePhoneLink = (phoneNumber: string): JSX.Element => {
-  if (phoneNumber) {
-    return (
-      <a href={`tel:${phoneNumber.replace(/-| /g, '')}`}>{phoneNumber.replace(/^\+1 /, '')}</a>
-    );
-  } else {
-    return <span />;
   }
 };
 

--- a/src/components/call/ContactDetails.tsx
+++ b/src/components/call/ContactDetails.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { TranslationFunction } from 'i18next';
 import { translate } from 'react-i18next';
 import { Issue, Contact, DefaultContact } from '../../common/model';
+import { ContactOffices } from './index';
 
 interface Props {
   readonly currentIssue: Issue;
@@ -23,7 +24,11 @@ const ContactDetails: React.StatelessComponent<Props> = ({ currentIssue, contact
           {contact.name} {contact.party ? `${contact.party.substring(0, 1)}-${contact.state}` : ''}
         </p>
         <p className="call__contact__phone">{makePhoneLink(contact.phone)}</p>
-        {renderFieldOffices(contact, t)}
+        <ContactOffices
+          currentIssue={currentIssue}
+          contactIndex={0}
+          t={t}
+        />
         <h3 className="call__contact__reason__header">
           {t('contact.whyYouAreCallingThisOffice')}
         </h3>
@@ -33,33 +38,11 @@ const ContactDetails: React.StatelessComponent<Props> = ({ currentIssue, contact
   }
 };
 
-const renderFieldOffices = (contact, t) => {
-  // TODO: account for state.showFieldOfficeNumbers == false
-  return (
-    <div>
-      <h3 className="call__contact__field-offices__header">{t('contact.localOfficeNumbers')}</h3>
-      <ul className="call__contact__field-office-list">
-        {contact.field_offices ? contact.field_offices.map(office =>
-          <li key={office.phone}>{makePhoneLink(office.phone)}{cityFormat(office, contact)}</li>
-        ) : <span />}
-      </ul>
-    </div>
-  );
-};
-
 const makePhoneLink = (phoneNumber: string): JSX.Element => {
   if (phoneNumber) {
     return (
       <a href={`tel:${phoneNumber.replace(/-| /g, '')}`}>{phoneNumber.replace(/^\+1 /, '')}</a>
     );
-  } else {
-    return <span />;
-  }
-};
-
-const cityFormat = (office, contact): JSX.Element => {
-  if (office.city) {
-    return <span>{` - ${office.city}, ${contact.state}`}</span>;
   } else {
     return <span />;
   }

--- a/src/components/call/ContactDetails.tsx
+++ b/src/components/call/ContactDetails.tsx
@@ -26,7 +26,7 @@ const ContactDetails: React.StatelessComponent<Props> = ({ currentIssue, contact
         <p className="call__contact__phone">{makePhoneLink(contact.phone)}</p>
         <ContactOffices
           currentIssue={currentIssue}
-          contactIndex={0}
+          contactIndex={contactIndex}
           t={t}
         />
         <h3 className="call__contact__reason__header">

--- a/src/components/call/ContactOffices.test.tsx
+++ b/src/components/call/ContactOffices.test.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import i18n from '../../services/i18n';
-import { ContactOffices } from './index'
+import { ContactOffices } from './index';
 import { Issue, DefaultIssue, Contact, DefaultContact, FieldOffice } from '../../common/model';
 
 test('Contact offices should display if available', () => {
-  const fieldOffice: FieldOffice = {city: 'San Francisco', phone: '5555551212' }
-  const contact: Contact = Object.assign({}, DefaultContact, { id: '101', name: 'dude', phone: '5555551212', party: '', state: 'CA', reason: 'this is your dude', fieldOffices: [fieldOffice] } )
+  const fieldOffice: FieldOffice = {city: 'San Francisco', phone: '5555551212' };
+  /*tslint:disable-next-line:max-line-length*/
+  const contact: Contact = Object.assign({}, DefaultContact, { id: '101', name: 'dude', phone: '5555551212', party: '', state: 'CA', reason: 'this is your dude', fieldOffices: [fieldOffice] } );
   const issue: Issue = Object.assign({}, DefaultIssue, { id: '1', name: 'testName', contacts: [contact] });
 
   const component = shallow(
@@ -16,12 +17,12 @@ test('Contact offices should display if available', () => {
       t={i18n.t}
     />
   );
-  const node = component.find('call__contact__field-office-list');
-  expect(node.children.length).toEqual(1);
+  expect(component).toMatchSnapshot();
 });
 
 test('Contact offices should not display if unavailable', () => {
-  const contact: Contact = Object.assign({}, DefaultContact, { id: '101', name: 'dude', phone: '5555551212', party: '', state: 'CA', reason: 'this is your dude' } )
+  /*tslint:disable-next-line:max-line-length*/
+  const contact: Contact = Object.assign({}, DefaultContact, { id: '101', name: 'dude', phone: '5555551212', party: '', state: 'CA', reason: 'this is your dude' } );
   const issue: Issue = Object.assign({}, DefaultIssue, { id: '1', name: 'testName', contacts: [contact] });
 
   const component = shallow(
@@ -31,6 +32,5 @@ test('Contact offices should not display if unavailable', () => {
       t={i18n.t}
     />
   );
-  const node = component.find('call__contact__field-office-list');
-  expect(node).toBeUndefined;
+  expect(component).toMatchSnapshot();
 });

--- a/src/components/call/ContactOffices.test.tsx
+++ b/src/components/call/ContactOffices.test.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import i18n from '../../services/i18n';
+import { ContactOffices } from './index'
+import { Issue, DefaultIssue, Contact, DefaultContact, FieldOffice } from '../../common/model';
+
+test('Contact offices should display if available', () => {
+  const fieldOffice: FieldOffice = {city: 'San Francisco', phone: '5555551212' }
+  const contact: Contact = Object.assign({}, DefaultContact, { id: '101', name: 'dude', phone: '5555551212', party: '', state: 'CA', reason: 'this is your dude', fieldOffices: [fieldOffice] } )
+  const issue: Issue = Object.assign({}, DefaultIssue, { id: '1', name: 'testName', contacts: [contact] });
+
+  const component = shallow(
+    <ContactOffices
+      currentIssue={issue}
+      contactIndex={0}
+      t={i18n.t}
+    />
+  );
+  const node = component.find('call__contact__field-office-list');
+  expect(node.length).toEqual(1);
+});

--- a/src/components/call/ContactOffices.test.tsx
+++ b/src/components/call/ContactOffices.test.tsx
@@ -17,5 +17,20 @@ test('Contact offices should display if available', () => {
     />
   );
   const node = component.find('call__contact__field-office-list');
-  expect(node.length).toEqual(1);
+  expect(node.children.length).toEqual(1);
+});
+
+test('Contact offices should not display if unavailable', () => {
+  const contact: Contact = Object.assign({}, DefaultContact, { id: '101', name: 'dude', phone: '5555551212', party: '', state: 'CA', reason: 'this is your dude' } )
+  const issue: Issue = Object.assign({}, DefaultIssue, { id: '1', name: 'testName', contacts: [contact] });
+
+  const component = shallow(
+    <ContactOffices
+      currentIssue={issue}
+      contactIndex={0}
+      t={i18n.t}
+    />
+  );
+  const node = component.find('call__contact__field-office-list');
+  expect(node).toBeUndefined;
 });

--- a/src/components/call/ContactOffices.tsx
+++ b/src/components/call/ContactOffices.tsx
@@ -16,8 +16,6 @@ export interface State {
 export class ContactOffices extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-
-    console.log("constructor");
     this.state = {showFieldOfficeNumbers: false};
   }
 
@@ -54,7 +52,7 @@ export class ContactOffices extends React.Component<Props, State> {
     } else {
       return (
         <div>
-          <p className="call__contact__show-field-offices">{this.props.t('contact.busyLine')}
+          <p className="call__contact__show-field-offices">{this.props.t('contact.busyLine')}&nbsp;
             <a onClick={this.showField}>{this.props.t('contact.busyLineGuidance')}</a>
           </p>
         </div>

--- a/src/components/call/ContactOffices.tsx
+++ b/src/components/call/ContactOffices.tsx
@@ -14,17 +14,18 @@ export interface State {
 }
 
 export class ContactOffices extends React.Component<Props, State> {
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
     this.state = {showFieldOfficeNumbers: false};
   }
 
   showField = () => {
     this.setState({showFieldOfficeNumbers: true});
-  };
+  }
   
   render() {
-    const contact: Contact = this.props.currentIssue.contacts && this.props.currentIssue.contacts.length !== 0 ? this.props.currentIssue.contacts[this.props.contactIndex] : DefaultContact;
+    const contact: Contact = this.props.currentIssue.contacts && this.props.currentIssue.contacts.length !== 0 ?
+      this.props.currentIssue.contacts[this.props.contactIndex] : DefaultContact;
 
     if (this.state.showFieldOfficeNumbers) {
       return (
@@ -40,12 +41,14 @@ export class ContactOffices extends React.Component<Props, State> {
     } else {
       return (
         <div>
-          <p className="call__contact__show-field-offices">{this.props.t('contact.busyLine')}  <a onClick={this.showField}>{this.props.t('contact.busyLineGuidance')}</a></p>
+          <p className="call__contact__show-field-offices">{this.props.t('contact.busyLine')}
+            <a onClick={this.showField}>{this.props.t('contact.busyLineGuidance')}</a>
+          </p>
         </div>
       );
     }  
   }
-};
+}
 
 const makePhoneLink = (phoneNumber: string): JSX.Element => {
   if (phoneNumber) {

--- a/src/components/call/ContactOffices.tsx
+++ b/src/components/call/ContactOffices.tsx
@@ -23,7 +23,8 @@ export class ContactOffices extends React.Component<Props, State> {
     this.setState({showFieldOfficeNumbers: true});
   }
 
-  // this component is reused and the local state is maintained through contact changes, we want the local state to reset when it's updated
+  // this component is reused and the local state is maintained through contact changes,
+  // we want the local state to reset when it's updated
   componentWillReceiveProps(nextProps: Props) {
     this.setState({showFieldOfficeNumbers: false});    
   }
@@ -32,9 +33,7 @@ export class ContactOffices extends React.Component<Props, State> {
     const contact: Contact = this.props.currentIssue.contacts && this.props.currentIssue.contacts.length !== 0 ?
       this.props.currentIssue.contacts[this.props.contactIndex] : DefaultContact;
 
-    console.log("rendering offices", contact);
-
-    if (contact.field_offices == null || contact.field_offices.length == 0) {
+    if (contact.field_offices == null || contact.field_offices.length === 0) {
       return (<span />);
     }
 

--- a/src/components/call/ContactOffices.tsx
+++ b/src/components/call/ContactOffices.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { TranslationFunction } from 'i18next';
 import { translate } from 'react-i18next';
 import { Issue, Contact, DefaultContact } from '../../common/model';
+import { makePhoneLink, cityFormat } from '../shared/jsxUtils';
 
 interface Props {
   readonly currentIssue: Issue;
@@ -59,24 +60,6 @@ export class ContactOffices extends React.Component<Props, State> {
     }  
   }
 }
-
-const makePhoneLink = (phoneNumber: string): JSX.Element => {
-  if (phoneNumber) {
-    return (
-      <a href={`tel:${phoneNumber.replace(/-| /g, '')}`}>{phoneNumber.replace(/^\+1 /, '')}</a>
-    );
-  } else {
-    return <span />;
-  }
-};
-
-const cityFormat = (office, contact): JSX.Element => {
-  if (office.city) {
-    return <span>{` - ${office.city}, ${contact.state}`}</span>;
-  } else {
-    return <span />;
-  }
-};
 
 export default translate()(ContactOffices);
 

--- a/src/components/call/ContactOffices.tsx
+++ b/src/components/call/ContactOffices.tsx
@@ -16,11 +16,18 @@ export interface State {
 export class ContactOffices extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
+
+    console.log("constructor");
     this.state = {showFieldOfficeNumbers: false};
   }
 
   showField = () => {
     this.setState({showFieldOfficeNumbers: true});
+  }
+
+  // this component is reused and the local state is maintained through contact changes, we want the local state to reset when it's updated
+  componentWillReceiveProps(nextProps: Props) {
+    this.setState({showFieldOfficeNumbers: false});    
   }
   
   render() {

--- a/src/components/call/ContactOffices.tsx
+++ b/src/components/call/ContactOffices.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { TranslationFunction } from 'i18next';
+import { translate } from 'react-i18next';
+import { Issue, Contact, DefaultContact } from '../../common/model';
+
+interface Props {
+  readonly currentIssue: Issue;
+  readonly contactIndex: number;
+  readonly t: TranslationFunction;
+}
+
+export interface State {
+  showFieldOfficeNumbers: Boolean;  
+}
+
+export class ContactOffices extends React.Component<Props, State> {
+  constructor(props) {
+    super(props);
+    this.state = {showFieldOfficeNumbers: false};
+  }
+
+  showField = () => {
+    this.setState({showFieldOfficeNumbers: true});
+  };
+  
+  render() {
+    const contact: Contact = this.props.currentIssue.contacts && this.props.currentIssue.contacts.length !== 0 ? this.props.currentIssue.contacts[this.props.contactIndex] : DefaultContact;
+
+    if (this.state.showFieldOfficeNumbers) {
+      return (
+        <div>
+          <h3 className="call__contact__field-offices__header">{this.props.t('contact.localOfficeNumbers')}</h3>
+          <ul className="call__contact__field-office-list">
+            {contact.field_offices ? contact.field_offices.map(office =>
+              <li key={office.phone}>{makePhoneLink(office.phone)}{cityFormat(office, contact)}</li>
+            ) : <span />}
+          </ul>
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          <p className="call__contact__show-field-offices">{this.props.t('contact.busyLine')}  <a onClick={this.showField}>{this.props.t('contact.busyLineGuidance')}</a></p>
+        </div>
+      );
+    }  
+  }
+};
+
+const makePhoneLink = (phoneNumber: string): JSX.Element => {
+  if (phoneNumber) {
+    return (
+      <a href={`tel:${phoneNumber.replace(/-| /g, '')}`}>{phoneNumber.replace(/^\+1 /, '')}</a>
+    );
+  } else {
+    return <span />;
+  }
+};
+
+const cityFormat = (office, contact): JSX.Element => {
+  if (office.city) {
+    return <span>{` - ${office.city}, ${contact.state}`}</span>;
+  } else {
+    return <span />;
+  }
+};
+
+export default translate()(ContactOffices);

--- a/src/components/call/ContactOffices.tsx
+++ b/src/components/call/ContactOffices.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export interface State {
-  showFieldOfficeNumbers: Boolean;  
+  showFieldOfficeNumbers: boolean;  
 }
 
 export class ContactOffices extends React.Component<Props, State> {
@@ -26,6 +26,12 @@ export class ContactOffices extends React.Component<Props, State> {
   render() {
     const contact: Contact = this.props.currentIssue.contacts && this.props.currentIssue.contacts.length !== 0 ?
       this.props.currentIssue.contacts[this.props.contactIndex] : DefaultContact;
+
+    console.log("rendering offices", contact);
+
+    if (contact.field_offices == null || contact.field_offices.length == 0) {
+      return (<span />);
+    }
 
     if (this.state.showFieldOfficeNumbers) {
       return (

--- a/src/components/call/ContactOffices.tsx
+++ b/src/components/call/ContactOffices.tsx
@@ -79,3 +79,5 @@ const cityFormat = (office, contact): JSX.Element => {
 };
 
 export default translate()(ContactOffices);
+
+export const ContactOfficesTranslatable = translate()(ContactOffices);

--- a/src/components/call/ContactOffices.tsx
+++ b/src/components/call/ContactOffices.tsx
@@ -27,7 +27,14 @@ export class ContactOffices extends React.Component<Props, State> {
   // this component is reused and the local state is maintained through contact changes,
   // we want the local state to reset when it's updated
   componentWillReceiveProps(nextProps: Props) {
-    this.setState({showFieldOfficeNumbers: false});    
+    const contact: Contact = this.props.currentIssue.contacts && this.props.currentIssue.contacts.length !== 0 ?
+      this.props.currentIssue.contacts[this.props.contactIndex] : DefaultContact;
+    const nextContact: Contact = nextProps.currentIssue.contacts && nextProps.currentIssue.contacts.length !== 0 ?
+      nextProps.currentIssue.contacts[nextProps.contactIndex] : DefaultContact;
+
+    if (contact !== nextContact) {
+      this.setState({showFieldOfficeNumbers: false});
+    }
   }
   
   render() {

--- a/src/components/call/Script.tsx
+++ b/src/components/call/Script.tsx
@@ -14,10 +14,14 @@ const Script: React.StatelessComponent<Props> = ({ issue, contactIndex = 0, t }:
     return (
       <div className="call__script">
         <h3 className="call__script__header">{t('script.yourScript')}</h3>
-        {issue.script}
-        {/* TODO: Format script and add issues link */}
-        {/* scriptFormat(state, prev, send) */}
-        {/* issuesLink(state, prev, send) */}
+        <div className="call__script__body">
+          {issue.script.split('\n').map(line => 
+          <p>{line}</p>
+          )}
+          {/* TODO: Format script and add issues link */}
+          {/* scriptFormat(state, prev, send) */}
+          {/* issuesLink(state, prev, send) */}
+        </div>
       </div>
     );
   } else {

--- a/src/components/call/Script.tsx
+++ b/src/components/call/Script.tsx
@@ -15,8 +15,8 @@ const Script: React.StatelessComponent<Props> = ({ issue, contactIndex = 0, t }:
       <div className="call__script">
         <h3 className="call__script__header">{t('script.yourScript')}</h3>
         <div className="call__script__body">
-          {issue.script.split('\n').map(line => 
-          <p>{line}</p>
+          {issue.script.split('\n').map((line, index) => 
+          <p key={index}>{line}</p>
           )}
           {/* TODO: Format script and add issues link */}
           {/* scriptFormat(state, prev, send) */}

--- a/src/components/call/__snapshots__/ContactOffices.test.tsx.snap
+++ b/src/components/call/__snapshots__/ContactOffices.test.tsx.snap
@@ -1,0 +1,287 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Contact offices should display if available 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <span />,
+  "nodes": Array [
+    <span />,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <ContactOffices
+        contactIndex={0}
+        currentIssue={
+                Object {
+                        "categories": Array [],
+                        "contacts": Array [
+                          Object {
+                            "fieldOffices": Array [
+                              Object {
+                                "city": "San Francisco",
+                                "phone": "5555551212",
+                              },
+                            ],
+                            "id": "101",
+                            "name": "dude",
+                            "party": "",
+                            "phone": "5555551212",
+                            "reason": "this is your dude",
+                            "state": "CA",
+                          },
+                        ],
+                        "id": "1",
+                        "inactive": false,
+                        "name": "testName",
+                        "reason": "",
+                        "script": "",
+                      }
+        }
+        t={[Function]}
+/>,
+      "_debugID": 1,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": ContactOffices {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "contactIndex": 0,
+          "currentIssue": Object {
+            "categories": Array [],
+            "contacts": Array [
+              Object {
+                "fieldOffices": Array [
+                  Object {
+                    "city": "San Francisco",
+                    "phone": "5555551212",
+                  },
+                ],
+                "id": "101",
+                "name": "dude",
+                "party": "",
+                "phone": "5555551212",
+                "reason": "this is your dude",
+                "state": "CA",
+              },
+            ],
+            "id": "1",
+            "inactive": false,
+            "name": "testName",
+            "reason": "",
+            "script": "",
+          },
+          "t": [Function],
+        },
+        "refs": Object {},
+        "showField": [Function],
+        "state": Object {
+          "showFieldOfficeNumbers": false,
+        },
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 1,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <span />,
+        "_debugID": 2,
+        "_renderedOutput": <span />,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <ContactOffices
+    contactIndex={0}
+    currentIssue={
+        Object {
+            "categories": Array [],
+            "contacts": Array [
+              Object {
+                "fieldOffices": Array [
+                  Object {
+                    "city": "San Francisco",
+                    "phone": "5555551212",
+                  },
+                ],
+                "id": "101",
+                "name": "dude",
+                "party": "",
+                "phone": "5555551212",
+                "reason": "this is your dude",
+                "state": "CA",
+              },
+            ],
+            "id": "1",
+            "inactive": false,
+            "name": "testName",
+            "reason": "",
+            "script": "",
+          }
+    }
+    t={[Function]}
+/>,
+}
+`;
+
+exports[`Contact offices should not display if unavailable 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <span />,
+  "nodes": Array [
+    <span />,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <ContactOffices
+        contactIndex={0}
+        currentIssue={
+                Object {
+                        "categories": Array [],
+                        "contacts": Array [
+                          Object {
+                            "id": "101",
+                            "name": "dude",
+                            "party": "",
+                            "phone": "5555551212",
+                            "reason": "this is your dude",
+                            "state": "CA",
+                          },
+                        ],
+                        "id": "1",
+                        "inactive": false,
+                        "name": "testName",
+                        "reason": "",
+                        "script": "",
+                      }
+        }
+        t={[Function]}
+/>,
+      "_debugID": 3,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": ContactOffices {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "contactIndex": 0,
+          "currentIssue": Object {
+            "categories": Array [],
+            "contacts": Array [
+              Object {
+                "id": "101",
+                "name": "dude",
+                "party": "",
+                "phone": "5555551212",
+                "reason": "this is your dude",
+                "state": "CA",
+              },
+            ],
+            "id": "1",
+            "inactive": false,
+            "name": "testName",
+            "reason": "",
+            "script": "",
+          },
+          "t": [Function],
+        },
+        "refs": Object {},
+        "showField": [Function],
+        "state": Object {
+          "showFieldOfficeNumbers": false,
+        },
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 2,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <span />,
+        "_debugID": 4,
+        "_renderedOutput": <span />,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <ContactOffices
+    contactIndex={0}
+    currentIssue={
+        Object {
+            "categories": Array [],
+            "contacts": Array [
+              Object {
+                "id": "101",
+                "name": "dude",
+                "party": "",
+                "phone": "5555551212",
+                "reason": "this is your dude",
+                "state": "CA",
+              },
+            ],
+            "id": "1",
+            "inactive": false,
+            "name": "testName",
+            "reason": "",
+            "script": "",
+          }
+    }
+    t={[Function]}
+/>,
+}
+`;

--- a/src/components/call/index.ts
+++ b/src/components/call/index.ts
@@ -1,6 +1,7 @@
 import { Call, CallTranslatable } from './Call';
 import CallDetail from './CallDetail';
 import ContactDetails from './ContactDetails';
+import ContactOffices from './ContactOffices';
 import CallPage from './CallPage';
 import CallPageContainer from './CallPageContainer';
 import Outcomes from './Outcomes';
@@ -9,5 +10,5 @@ import NoContactSplitDistrict from './NoContactSplitDistrict';
 
 export {
   Call, CallTranslatable, CallPageContainer, CallDetail, CallPage,
-  ContactDetails, Outcomes, Script, NoContactSplitDistrict
+  ContactDetails, ContactOffices, Outcomes, Script, NoContactSplitDistrict
 };

--- a/src/components/call/index.ts
+++ b/src/components/call/index.ts
@@ -1,7 +1,7 @@
 import { Call, CallTranslatable } from './Call';
 import CallDetail from './CallDetail';
 import ContactDetails from './ContactDetails';
-import ContactOffices from './ContactOffices';
+import { ContactOffices, ContactOfficesTranslatable } from './ContactOffices';
 import CallPage from './CallPage';
 import CallPageContainer from './CallPageContainer';
 import Outcomes from './Outcomes';
@@ -10,5 +10,5 @@ import NoContactSplitDistrict from './NoContactSplitDistrict';
 
 export {
   Call, CallTranslatable, CallPageContainer, CallDetail, CallPage,
-  ContactDetails, ContactOffices, Outcomes, Script, NoContactSplitDistrict
+  ContactDetails, ContactOffices, ContactOfficesTranslatable, Outcomes, Script, NoContactSplitDistrict
 };

--- a/src/components/shared/jsxUtils.tsx
+++ b/src/components/shared/jsxUtils.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { FieldOffice, Contact } from '../../common/model';
+
+export const makePhoneLink = (phoneNumber: string): JSX.Element => {
+  if (phoneNumber) {
+    return (
+      <a href={`tel:${phoneNumber.replace(/-| /g, '')}`}>{phoneNumber.replace(/^\+1 /, '')}</a>
+    );
+  } else {
+    return <span />;
+  }
+};
+
+export const cityFormat = (office: FieldOffice, contact: Contact): JSX.Element => {
+  if (office.city) {
+    return <span>{` - ${office.city}, ${contact.state}`}</span>;
+  } else {
+    return <span />;
+  }
+};

--- a/src/redux/callState/reducer.ts
+++ b/src/redux/callState/reducer.ts
@@ -22,7 +22,6 @@ export interface CallState {
   currentIssueId: string;
   contactIndexes: string[];
   completedIssueIds: string[];
-  showFieldOfficeNumbers: boolean;
 }
 
 /*


### PR DESCRIPTION
My first React/Typescript PR! Working on #24. I don't fully understand everything yet so please let me know where I'm going in the wrong direction.

Extracted this into its own component for local state. It's possible this could have been done in `ContactDetails` but I wanted to experiment with non-stateless components in fresh code.

Some questions:
* Should this be a single component by converting `ContactDetails` to `React.Component`?
   @cdoremus **answer:** If you need to use a lifecycle method, have `ContactDetails` extend `React.Component`. If you feel you need to encapsulate logic in methods, you can create a stateless component class by extending `React.PureComponent<Props>`
* `makePhoneLink` is now duplicated, it obviously should not be. If we're going with both components, how does one share this code between both?
@cdoremus **answer:** Put `makePhoneLink` in a separate utility module in the `shared` folder that each  component imports and calls.