### PR TITLE
Persist and rehydrate completed issues ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "start": "node scripts/start.js",
     "start:https": "HTTPS=true node scripts/start.js",
     "build": "node scripts/build.js",
-    "test": "npm run tslint && node scripts/test.js --env=jsdom",
+    "test": "npm run tslint && npm run test:nolint",
+    "test:nolint": "node scripts/test.js --env=jsdom",
     "test:coverage": "node scripts/test.js --env=jsdom --coverage",
     "tslint": "tslint 'src/**/*.ts' 'src/**/*.tsx'",
     "postinstall": "npm run build-css"

--- a/src/components/call/Call.test.tsx
+++ b/src/components/call/Call.test.tsx
@@ -9,7 +9,7 @@ test('Call component should be rendered if passed a valid object', () => {
   const issue: Issue = Object.assign({}, DefaultIssue, { id: '1', name: 'testName' });
   let callState: CallState = {
     currentIssueId: 'test1',
-    contactIndexes: [{'test1': 2}, {'test2': 1}],
+    contactIndexes: {'test1': 2, 'test2': 1},
     completedIssueIds: ['test1', 'test2'],
   };
 

--- a/src/components/call/Call.test.tsx
+++ b/src/components/call/Call.test.tsx
@@ -9,7 +9,7 @@ test('Call component should be rendered if passed a valid object', () => {
   const issue: Issue = Object.assign({}, DefaultIssue, { id: '1', name: 'testName' });
   let callState: CallState = {
     currentIssueId: 'test1',
-    contactIndexes: ['test1', 'test2'],
+    contactIndexes: [{'test1': 2}, {'test2': 1}],
     completedIssueIds: ['test1', 'test2'],
   };
 

--- a/src/redux/callState/action.ts
+++ b/src/redux/callState/action.ts
@@ -1,13 +1,13 @@
 import { Action } from 'redux';
 import { OutcomeData, CallStateAction } from './index';
 
-export type CallStateActionType =
-  'CURRENT_ISSUE_SELECTED' |
-  'COMPLETE_ISSUE' |
-  'NEXT_CONTACT' |
-  'SET_CONTACT_IDS' |
-  'SET_SHOW_FIELD_OFFICE_NUMBERS'
-  ;
+export enum CallStateActionType {
+  CURRENT_ISSUE_SELECTED = 'CURRENT_ISSUE_SELECTED',
+  COMPLETE_ISSUE = 'COMPLETE_ISSUE',
+  NEXT_CONTACT = 'NEXT_CONTACT',
+  SET_CONTACT_IDS = 'SET_CONTACT_IDS',
+  SET_SHOW_FIELD_OFFICE_NUMBERS = 'SET_SHOW_FIELD_OFFICE_NUMBERS'
+}
 
 export interface CallStateAction extends Action {
   type: CallStateActionType;
@@ -20,25 +20,25 @@ export interface CallStateAction extends Action {
   See /src/redux/callState/actionCreator.ts for next step(3) in Redux Data Flow
 */
 export interface CurrentIssueAction extends CallStateAction {
-  type: 'CURRENT_ISSUE_SELECTED';
+  type: CallStateActionType.CURRENT_ISSUE_SELECTED;
   payload: string;
 }
 
 export interface SubmitOutcomeAction extends CallStateAction {
-  type: 'COMPLETE_ISSUE';
+  type: CallStateActionType.COMPLETE_ISSUE;
   payload: OutcomeData;
 }
 
 export interface NextContact extends CallStateAction {
-  type: 'NEXT_CONTACT';
+  type: CallStateActionType.NEXT_CONTACT;
 }
 
 export interface SetContactIdsAction extends CallStateAction {
-  type: 'SET_CONTACT_IDS';
+  type: CallStateActionType.SET_CONTACT_IDS;
   payload: string[];
 }
 
 export interface SetShowFieldOfficeNumbers extends CallStateAction {
-  type: 'SET_SHOW_FIELD_OFFICE_NUMBERS';
+  type: CallStateActionType.SET_SHOW_FIELD_OFFICE_NUMBERS;
   payload: boolean;
 }

--- a/src/redux/callState/action.ts
+++ b/src/redux/callState/action.ts
@@ -1,5 +1,5 @@
 import { Action } from 'redux';
-import { OutcomeData, CallStateAction } from './index';
+import { CallStateAction } from './index';
 
 export enum CallStateActionType {
   CURRENT_ISSUE_SELECTED = 'CURRENT_ISSUE_SELECTED',
@@ -25,9 +25,8 @@ export interface CurrentIssueAction extends CallStateAction {
   payload: string;
 }
 
-export interface SubmitOutcomeAction extends CallStateAction {
+export interface CompleteIssueAction extends CallStateAction {
   type: CallStateActionType.COMPLETE_ISSUE;
-  payload: OutcomeData;
 }
 
 export interface NextContact extends CallStateAction {

--- a/src/redux/callState/action.ts
+++ b/src/redux/callState/action.ts
@@ -6,7 +6,8 @@ export enum CallStateActionType {
   COMPLETE_ISSUE = 'COMPLETE_ISSUE',
   NEXT_CONTACT = 'NEXT_CONTACT',
   SET_CONTACT_IDS = 'SET_CONTACT_IDS',
-  SET_SHOW_FIELD_OFFICE_NUMBERS = 'SET_SHOW_FIELD_OFFICE_NUMBERS'
+  SET_SHOW_FIELD_OFFICE_NUMBERS = 'SET_SHOW_FIELD_OFFICE_NUMBERS',
+  CLEAR_CONTACT_INDEXES = 'CLEAR_CONTACT_INDEXES'
 }
 
 export interface CallStateAction extends Action {
@@ -41,4 +42,8 @@ export interface SetContactIdsAction extends CallStateAction {
 export interface SetShowFieldOfficeNumbers extends CallStateAction {
   type: CallStateActionType.SET_SHOW_FIELD_OFFICE_NUMBERS;
   payload: boolean;
+}
+
+export interface ClearContactIndexesAction extends CallStateAction {
+  type: CallStateActionType.CLEAR_CONTACT_INDEXES;
 }

--- a/src/redux/callState/action.ts
+++ b/src/redux/callState/action.ts
@@ -27,6 +27,7 @@ export interface CurrentIssueAction extends CallStateAction {
 
 export interface CompleteIssueAction extends CallStateAction {
   type: CallStateActionType.COMPLETE_ISSUE;
+  payload?: string;
 }
 
 export interface NextContact extends CallStateAction {

--- a/src/redux/callState/actionCreator.ts
+++ b/src/redux/callState/actionCreator.ts
@@ -1,5 +1,6 @@
 import { OutcomeData, CurrentIssueAction,
-  SubmitOutcomeAction, NextContact, CallStateActionType } from './index';
+  SubmitOutcomeAction, NextContact,
+  CallStateActionType, ClearContactIndexesAction } from './index';
 
 /* REDUX DATA FLOW 3: At this point in the data flow, the IssueListItem View Component was clicked, the method was
     passed up through the Redux Container which called this actionCreator.
@@ -28,5 +29,11 @@ export const completeIssueActionCreator = (outcomeData: OutcomeData): SubmitOutc
 export const moveToNextActionCreator = (): NextContact => {
   return {
     type: CallStateActionType.NEXT_CONTACT
+  };
+};
+
+export const clearContactIndexes = (): ClearContactIndexesAction => {
+  return {
+    type: CallStateActionType.CLEAR_CONTACT_INDEXES
   };
 };

--- a/src/redux/callState/actionCreator.ts
+++ b/src/redux/callState/actionCreator.ts
@@ -1,9 +1,10 @@
-import { OutcomeData, CurrentIssueAction, SubmitOutcomeAction, NextContact } from './index';
+import { OutcomeData, CurrentIssueAction,
+  SubmitOutcomeAction, NextContact, CallStateActionType } from './index';
 
-/* REDUX DATA FLOW 3: At this point in the data flow, the IssueListItem View Component was clicked, the method was 
+/* REDUX DATA FLOW 3: At this point in the data flow, the IssueListItem View Component was clicked, the method was
     passed up through the Redux Container which called this actionCreator.
     This action creator will create an object(defined as an "action") that has a
-    defined type ('CURRENT_ISSUE_SELECTED') which is constrained by an enum in the 
+    defined type ('CURRENT_ISSUE_SELECTED') which is constrained by an enum in the
     action.ts file. It also has a payload that is also defined in the action.ts file.
 
     Redux will then "Dispatch" that object, which will send this object through the reducers.
@@ -12,20 +13,20 @@ import { OutcomeData, CurrentIssueAction, SubmitOutcomeAction, NextContact } fro
  */
 export const selectIssueActionCreator = (issueId: string): CurrentIssueAction => {
   return {
-    type: 'CURRENT_ISSUE_SELECTED',
+    type: CallStateActionType.CURRENT_ISSUE_SELECTED,
     payload: issueId
   };
 };
 
 export const completeIssueActionCreator = (outcomeData: OutcomeData): SubmitOutcomeAction => {
   return {
-    type: 'COMPLETE_ISSUE',
+    type: CallStateActionType.COMPLETE_ISSUE,
     payload: outcomeData
   };
 };
 
 export const moveToNextActionCreator = (): NextContact => {
   return {
-    type: 'NEXT_CONTACT'
+    type: CallStateActionType.NEXT_CONTACT
   };
 };

--- a/src/redux/callState/actionCreator.ts
+++ b/src/redux/callState/actionCreator.ts
@@ -19,10 +19,11 @@ export const selectIssueActionCreator = (issueId: string): CurrentIssueAction =>
   };
 };
 
-export const completeIssueActionCreator = (): CompleteIssueAction => {
+export const completeIssueActionCreator = (issueId?: string): CompleteIssueAction => {
   // completes the current issue: callState.currentIssueId
   return {
-    type: CallStateActionType.COMPLETE_ISSUE
+    type: CallStateActionType.COMPLETE_ISSUE,
+    payload: issueId
   };
 };
 

--- a/src/redux/callState/actionCreator.ts
+++ b/src/redux/callState/actionCreator.ts
@@ -1,5 +1,5 @@
-import { OutcomeData, CurrentIssueAction,
-  SubmitOutcomeAction, NextContact,
+import { CurrentIssueAction,
+  CompleteIssueAction, NextContact,
   CallStateActionType, ClearContactIndexesAction } from './index';
 
 /* REDUX DATA FLOW 3: At this point in the data flow, the IssueListItem View Component was clicked, the method was
@@ -19,10 +19,10 @@ export const selectIssueActionCreator = (issueId: string): CurrentIssueAction =>
   };
 };
 
-export const completeIssueActionCreator = (outcomeData: OutcomeData): SubmitOutcomeAction => {
+export const completeIssueActionCreator = (): CompleteIssueAction => {
+  // completes the current issue: callState.currentIssueId
   return {
-    type: CallStateActionType.COMPLETE_ISSUE,
-    payload: outcomeData
+    type: CallStateActionType.COMPLETE_ISSUE
   };
 };
 

--- a/src/redux/callState/asyncActionCreator.ts
+++ b/src/redux/callState/asyncActionCreator.ts
@@ -58,7 +58,7 @@ export function submitOutcome(data: OutcomeData) {
       // send('incrementContact', data, done);
 
       if ( data.numberContactsLeft === 0 ) {
-        return dispatch(completeIssueActionCreator(data));
+        return dispatch(completeIssueActionCreator());
       } else {
         return dispatch(moveToNextActionCreator());
       }

--- a/src/redux/callState/index.ts
+++ b/src/redux/callState/index.ts
@@ -1,7 +1,8 @@
 export { CallStateAction, CallStateActionType,
   CurrentIssueAction, NextContact,
   SetContactIdsAction, SetShowFieldOfficeNumbers,
-  SubmitOutcomeAction } from './action';
-export {completeIssueActionCreator, moveToNextActionCreator, selectIssueActionCreator} from './actionCreator';
+  SubmitOutcomeAction, ClearContactIndexesAction } from './action';
+export {completeIssueActionCreator, moveToNextActionCreator,
+  selectIssueActionCreator, clearContactIndexes } from './actionCreator';
 export { callStateReducer, CallState } from './reducer';
 export { OutcomeData, OutcomeType, submitOutcome } from './asyncActionCreator';

--- a/src/redux/callState/index.ts
+++ b/src/redux/callState/index.ts
@@ -1,7 +1,7 @@
 export { CallStateAction, CallStateActionType,
   CurrentIssueAction, NextContact,
   SetContactIdsAction, SetShowFieldOfficeNumbers,
-  SubmitOutcomeAction, ClearContactIndexesAction } from './action';
+  CompleteIssueAction, ClearContactIndexesAction } from './action';
 export {completeIssueActionCreator, moveToNextActionCreator,
   selectIssueActionCreator, clearContactIndexes } from './actionCreator';
 export { callStateReducer, CallState } from './reducer';

--- a/src/redux/callState/reducer.test.ts
+++ b/src/redux/callState/reducer.test.ts
@@ -1,0 +1,59 @@
+import { CallState, CurrentIssueAction, NextContact,
+  CallStateActionType, callStateReducer,
+  CompleteIssueAction, ClearContactIndexesAction } from './';
+
+let defaultState: CallState;
+beforeEach(() => {
+  defaultState = {
+    currentIssueId: '',
+    contactIndexes: {},
+    completedIssueIds: []
+  };
+});
+
+test('Call State reducer processes CURRENT_ISSUE_SELECTED action', () => {
+  const issueId = 'issue1';
+  const state = { ...defaultState };
+  const action: CurrentIssueAction = {
+    type: CallStateActionType.CURRENT_ISSUE_SELECTED,
+    payload: issueId
+  };
+  const newState = callStateReducer(state, action);
+  expect(newState.currentIssueId).toEqual(issueId);
+});
+
+test('Call State reducer processes NEXT_CONTACT action', () => {
+  const issueId1 = 'issue1';
+  const issueId1Index = 1;
+  const contactIndexes = {'issue1': 1, 'issue2': 2};
+  const state = { ...defaultState, contactIndexes, currentIssueId: issueId1 };
+  const action: NextContact = {
+    type: CallStateActionType.NEXT_CONTACT
+  };
+  const newState = callStateReducer(state, action);
+  // console.log('NEW STATE', newState);
+  expect(newState.contactIndexes[issueId1]).toEqual(issueId1Index + 1);
+});
+
+test('Call State reducer processes COMPLETE_ISSUE action', () => {
+  const issueId1 = 'issue1';
+  const completedIssues = ['issue2', 'issue3'];
+  const state = { ...defaultState, currentIssueId: issueId1, completedIssues };
+  const action: CompleteIssueAction = {
+    type: CallStateActionType.COMPLETE_ISSUE
+  };
+  const newState = callStateReducer(state, action);
+  // console.log('NEW STATE', newState);
+  expect(newState.completedIssueIds).toContain(issueId1);
+});
+
+test('Call State reducer processes CLEAR_CONTACT_INDEXES action', () => {
+  const contactIndexes = {'issue1': 1, 'issue2': 2};
+  const state = { ...defaultState, contactIndexes };
+  const action: ClearContactIndexesAction = {
+    type: CallStateActionType.CLEAR_CONTACT_INDEXES
+  };
+  const newState = callStateReducer(state, action);
+  // console.log('NEW STATE', newState);
+  expect(newState.contactIndexes).toEqual({});
+});

--- a/src/redux/callState/reducer.test.ts
+++ b/src/redux/callState/reducer.test.ts
@@ -35,16 +35,32 @@ test('Call State reducer processes NEXT_CONTACT action', () => {
   expect(newState.contactIndexes[issueId1]).toEqual(issueId1Index + 1);
 });
 
-test('Call State reducer processes COMPLETE_ISSUE action', () => {
+test('Call State reducer processes COMPLETE_ISSUE action with callState.currentIssueId', () => {
   const issueId1 = 'issue1';
   const completedIssues = ['issue2', 'issue3'];
-  const state = { ...defaultState, currentIssueId: issueId1, completedIssues };
+  const state = { ...defaultState, currentIssueId: issueId1, completedIssueIds: completedIssues };
   const action: CompleteIssueAction = {
     type: CallStateActionType.COMPLETE_ISSUE
   };
   const newState = callStateReducer(state, action);
   // console.log('NEW STATE', newState);
   expect(newState.completedIssueIds).toContain(issueId1);
+  expect(newState.completedIssueIds.length).toEqual(3);
+});
+
+test('Call State reducer processes COMPLETE_ISSUE action with issueId argument', () => {
+  const issueId = 'issue4';
+  const completedIssues = ['issue2', 'issue3'];
+  const state = { ...defaultState, completedIssueIds: completedIssues };
+  // console.log('OLD STATE', state);
+  const action: CompleteIssueAction = {
+    type: CallStateActionType.COMPLETE_ISSUE,
+    payload: issueId
+  };
+  const newState = callStateReducer(state, action);
+  // console.log('NEW STATE', newState);
+  expect(newState.completedIssueIds).toContain(issueId);
+  expect(newState.completedIssueIds.length).toEqual(3);
 });
 
 test('Call State reducer processes CLEAR_CONTACT_INDEXES action', () => {

--- a/src/redux/callState/reducer.ts
+++ b/src/redux/callState/reducer.ts
@@ -21,7 +21,7 @@ import { CallStateAction, CallStateActionType } from './index';
 export interface CallState {
   currentIssueId: string;
   // key is the issueId, value is the index of the last contact visited
-  contactIndexes: {[key: string]: number}[];
+  contactIndexes: {[key: string]: number};
   completedIssueIds: string[];
 }
 
@@ -83,7 +83,7 @@ export const callStateReducer: Reducer<CallState> = (
       }
       return { ...state, contactIndexes: newIndexes };
     case CallStateActionType.CLEAR_CONTACT_INDEXES:
-      return { ...state, contactIndexes: []};
+      return { ...state, contactIndexes: {}};
     default:
       return state;
   }

--- a/src/redux/callState/reducer.ts
+++ b/src/redux/callState/reducer.ts
@@ -1,5 +1,5 @@
 import { Reducer } from 'redux';
-import { CallStateAction } from './index';
+import { CallStateAction, CallStateActionType } from './index';
 
 /*
   REDUX DATA FLOW 4: When the selectIssueActionCreator has been dispatched, it returns the
@@ -43,7 +43,7 @@ export const callStateReducer: Reducer<CallState> = (
   state: CallState = {} as CallState,
   action: CallStateAction): CallState => {
   switch (action.type) {
-    case 'CURRENT_ISSUE_SELECTED':
+    case CallStateActionType.CURRENT_ISSUE_SELECTED:
       /*
         REDUX DATA FLOW 5: This type is seen when our action is dispatched and so this reducer switch
         case is run.  In, this case, it takes the existing state and puts it into a new object. It
@@ -65,7 +65,7 @@ export const callStateReducer: Reducer<CallState> = (
         End of Redux Data Flow
       */
       return Object.assign({}, state, { currentIssueId: action.payload });
-    case 'COMPLETE_ISSUE':
+    case CallStateActionType.COMPLETE_ISSUE:
       let newCompletedIssues: string[] = [];
       if (state.completedIssueIds) {
         newCompletedIssues = [...state.completedIssueIds];
@@ -74,7 +74,7 @@ export const callStateReducer: Reducer<CallState> = (
       let newState = { ...state };
       newState.completedIssueIds = newCompletedIssues;
       return newState;
-    case 'NEXT_CONTACT':
+    case CallStateActionType.NEXT_CONTACT:
       let newIndexes = { ...state.contactIndexes };
       if (!newIndexes[state.currentIssueId]) {
         newIndexes[state.currentIssueId] = 1;
@@ -82,6 +82,8 @@ export const callStateReducer: Reducer<CallState> = (
         newIndexes[state.currentIssueId]++;
       }
       return { ...state, contactIndexes: newIndexes };
+    case CallStateActionType.CLEAR_CONTACT_INDEXES:
+      return { ...state, contactIndexes: []};
     default:
       return state;
   }

--- a/src/redux/callState/reducer.ts
+++ b/src/redux/callState/reducer.ts
@@ -70,7 +70,12 @@ export const callStateReducer: Reducer<CallState> = (
       if (state.completedIssueIds) {
         newCompletedIssues = [...state.completedIssueIds];
       }
-      newCompletedIssues.push(state.currentIssueId);
+      const payload = action.payload as string;
+      if (payload) {
+        newCompletedIssues.push(payload);
+      } else {
+        newCompletedIssues.push(state.currentIssueId);
+      }
       let newState = { ...state };
       newState.completedIssueIds = newCompletedIssues;
       return newState;

--- a/src/redux/callState/reducer.ts
+++ b/src/redux/callState/reducer.ts
@@ -2,12 +2,12 @@ import { Reducer } from 'redux';
 import { CallStateAction } from './index';
 
 /*
-  REDUX DATA FLOW 4: When the selectIssueActionCreator has been dispatched, it returns the 
+  REDUX DATA FLOW 4: When the selectIssueActionCreator has been dispatched, it returns the
   action object with type 'CURRENT_ISSUE_SELECTED'.  The Redux Store basically has a big
   switch statement where if it sees the action type of the action, it will run the associated logic
-  in that switch case.  
+  in that switch case.
     And, it will act only on the key(or section, it is basically a dictionary) of the Redux store
-  (in this file the key is "callState").  Look into the /src/redux/root.ts file to see the 
+  (in this file the key is "callState").  Look into the /src/redux/root.ts file to see the
   combineReducers method that puts all of the reducers together and defines your redux keys.
 
   See below in reducer for next step(5) in Redux Data Flow
@@ -20,7 +20,8 @@ import { CallStateAction } from './index';
 */
 export interface CallState {
   currentIssueId: string;
-  contactIndexes: string[];
+  // key is the issueId, value is the index of the last contact visited
+  contactIndexes: {[key: string]: number}[];
   completedIssueIds: string[];
 }
 
@@ -28,14 +29,14 @@ export interface CallState {
   Redux convention is that we always return a new copy of the state.  We never change the existing copy.
   If the state of this key is null/undefined, we return the default value(in this case "{}").
 
-  This(...state.completedIssueIds) is using the new ES6 "Spread" operator. 
+  This(...state.completedIssueIds) is using the new ES6 "Spread" operator.
   It will take the existing array and break it into individual components.
   In the code below, it is "spreading" the completedIssueIds array into individual items that
     are then put back into a new array.  This allows us to stick to the conventions of never
     altering the state but always creating a new object(in this case a new array)
   newCompletedIssues = [...state.completedIssueIds];
 
-  The spread operator also works with objects and you will often see it in reducers in place of 
+  The spread operator also works with objects and you will often see it in reducers in place of
   "Object.assign" that is used here.
 */
 export const callStateReducer: Reducer<CallState> = (
@@ -45,19 +46,19 @@ export const callStateReducer: Reducer<CallState> = (
     case 'CURRENT_ISSUE_SELECTED':
       /*
         REDUX DATA FLOW 5: This type is seen when our action is dispatched and so this reducer switch
-        case is run.  In, this case, it takes the existing state and puts it into a new object. It 
+        case is run.  In, this case, it takes the existing state and puts it into a new object. It
         then overwrites the currentIssueId property on that state with the action.payload which is the
         new issueId that we submitted all the way back when we clicked on the IssueListItem component.
 
-        You could at this point subscribe to the store to listen to this event and perform an action 
-          in response to it.  We don't currently subscribe to events explicitly in this app. 
-        
+        You could at this point subscribe to the store to listen to this event and perform an action
+          in response to it.  We don't currently subscribe to events explicitly in this app.
+
         If you have data that you have retrieved from Redux that you have saved to "Local" state in a component
         through the "SetState" method, and it is changed through a reducer, the redux container will see this
         and make your component aware of it.  The component will then re-render itself.  React Components,
         by default, re-render themselves whenever their "Local" state changes.
-        
-        For example, if we saved the ApplicationState.callState.currentIssueId to "Local" state in 
+
+        For example, if we saved the ApplicationState.callState.currentIssueId to "Local" state in
         "HomePage" component(which we actually couldn't because it is a stateless component but just hypothetically),
         it would get re-rendered because of this change to it's value the Redux store.
 

--- a/src/redux/remoteData/asyncActionCreator.ts
+++ b/src/redux/remoteData/asyncActionCreator.ts
@@ -5,7 +5,7 @@ import { setCachedCity, setLocation, setLocationFetchType,
   setSplitDistrict, setUiState } from '../location/index';
 import { getLocationByIP, getBrowserGeolocation, GEOLOCATION_TIMEOUT } from '../../services/geolocationServices';
 import { issuesActionCreator, callCountActionCreator, apiErrorMessageActionCreator } from './index';
-import { clearContactIndexes, completeIssueActionCreator, selectIssueActionCreator } from '../callState/';
+import { clearContactIndexes, completeIssueActionCreator } from '../callState/';
 import { ApplicationState } from '../root';
 import { LocationUiState } from '../../common/model';
 /**
@@ -152,8 +152,7 @@ const migrateLegacyCompletedIssues = (dispatch: Dispatch<ApplicationState>) => {
   if (legacyCompletedIssues) {
     const ids = JSON.parse(legacyCompletedIssues);
     ids.forEach((id) => {
-      dispatch(selectIssueActionCreator(id));
-      dispatch(completeIssueActionCreator());
+      dispatch(completeIssueActionCreator(id));
     });
     localStorage.removeItem(LEGACY_COMPLETED_ISSUES_KEY);
   }

--- a/src/redux/remoteData/asyncActionCreator.ts
+++ b/src/redux/remoteData/asyncActionCreator.ts
@@ -1,12 +1,13 @@
 import { Dispatch } from 'redux';
 import { ApiData, IpInfoData, LocationFetchType, ReportData } from './../../common/model';
 import { get5CallsApiData, getReportData } from '../../services/apiServices';
-import { setCachedCity, setLocation, setLocationFetchType, setSplitDistrict } from '../location/index';
+import { setCachedCity, setLocation, setLocationFetchType,
+  setSplitDistrict, setUiState } from '../location/index';
 import { getLocationByIP, getBrowserGeolocation, GEOLOCATION_TIMEOUT } from '../../services/geolocationServices';
 import { issuesActionCreator, callCountActionCreator, apiErrorMessageActionCreator } from './index';
+import { clearContactIndexes } from '../callState/';
 import { ApplicationState } from '../root';
 import { LocationUiState } from '../../common/model';
-import { setUiState } from './../location';
 /**
  * Timer for calling fetchLocationByIP() if
  * fetchBrowserGeolocation() fails or times out.
@@ -125,7 +126,10 @@ export const startup = () => {
   return (dispatch: Dispatch<ApplicationState>,
           getState: () => ApplicationState) => {
     dispatch(setUiState(LocationUiState.FETCHING_LOCATION));
-    let state = getState();
+    const state = getState();
+    // clear contact indexes loaded from local storage
+    dispatch(clearContactIndexes());
+
     const loc = state.locationState.address || state.locationState.cachedCity;
     if (loc) {
       // console.log('Using cached address');

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -38,7 +38,8 @@ export default (initialState) => {
   // Make sure every key is of type ApplicationStateKeyType
   // and every value is an ApplicationStateKey value
   const localPersistKeys: ApplicationStateKeyType[] = [
-    ApplicationStateKey.locationState
+    ApplicationStateKey.locationState,
+    ApplicationStateKey.callState
   ];
   persistor = persistStore(
     store,


### PR DESCRIPTION
Persists and rehydrates completed issues ids from local storage using `redux-persist`. This will fix issue #29 

Also added code to migrate completed issue ids stored in local storage persisted by the Choo app to `callState.completedIssueIds`.

Part of this PR includes converting `CallStateActionType` to a string-based enum.