### PR TITLE
More Issues Page

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -2,8 +2,10 @@
 export const APP_NAME = '5 Calls';
 export const APP_URL = 'https://5calls.org';
 // export const APP_URL = 'http://localhost:8090';
+export const API_URL = 'https://api.5calls.org/v1';
 export const ISSUES_API_URL = `${APP_URL}/issues/?all=true&address=`;
-export const REPORT_API_URL = `${APP_URL}/report`;
+export const REGISTER_CALL_API_URL = `${APP_URL}/report`;
+export const REPORT_API_URL = `${API_URL}/counts`;
 export const IP_INFO_URL = 'https://ipinfo.io/json';
 
 export const zipCodeRegex: RegExp = /^\d{5}(-\d{4})?$/;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,17 +1,9 @@
 
 export const APP_NAME = '5 Calls';
-<<<<<<< a26b5303687b205b71f998717e7ec521b45788c1
 export const APP_URL = 'https://5calls.org';
-export const API_URL = 'https://api.5calls.org/v1';
-export const ISSUES_API_URL = `${APP_URL}/issues/?address=`;
-export const REGISTER_CALL_API_URL = `${APP_URL}/report`;
-export const REPORT_API_URL = `${API_URL}/counts`;
-=======
-// export const APP_URL = 'https://5calls.org';
-export const APP_URL = 'http://localhost:8090';
+// export const APP_URL = 'http://localhost:8090';
 export const ISSUES_API_URL = `${APP_URL}/issues/?all=true&address=`;
 export const REPORT_API_URL = `${APP_URL}/report`;
->>>>>>> Some refactoring and almost done with the more issues page.
 export const IP_INFO_URL = 'https://ipinfo.io/json';
 
 export const zipCodeRegex: RegExp = /^\d{5}(-\d{4})?$/;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,10 +1,17 @@
 
 export const APP_NAME = '5 Calls';
+<<<<<<< a26b5303687b205b71f998717e7ec521b45788c1
 export const APP_URL = 'https://5calls.org';
 export const API_URL = 'https://api.5calls.org/v1';
 export const ISSUES_API_URL = `${APP_URL}/issues/?address=`;
 export const REGISTER_CALL_API_URL = `${APP_URL}/report`;
 export const REPORT_API_URL = `${API_URL}/counts`;
+=======
+// export const APP_URL = 'https://5calls.org';
+export const APP_URL = 'http://localhost:8090';
+export const ISSUES_API_URL = `${APP_URL}/issues/?all=true&address=`;
+export const REPORT_API_URL = `${APP_URL}/report`;
+>>>>>>> Some refactoring and almost done with the more issues page.
 export const IP_INFO_URL = 'https://ipinfo.io/json';
 
 export const zipCodeRegex: RegExp = /^\d{5}(-\d{4})?$/;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -4,8 +4,8 @@ export const APP_URL = 'https://5calls.org';
 // export const APP_URL = 'http://localhost:8090';
 export const API_URL = 'https://api.5calls.org/v1';
 export const ISSUES_API_URL = `${APP_URL}/issues/?all=true&address=`;
-export const REGISTER_CALL_API_URL = `${APP_URL}/report`;
-export const REPORT_API_URL = `${API_URL}/counts`;
+export const REPORT_API_URL = `${APP_URL}/report`;
+export const COUNTS_API_URL = `${API_URL}/counts`;
 export const IP_INFO_URL = 'https://ipinfo.io/json';
 
 export const zipCodeRegex: RegExp = /^\d{5}(-\d{4})?$/;

--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -103,7 +103,7 @@ export interface ApiData {
   issues: Issue[];
 }
 
-export interface ReportData {
+export interface CountData {
   count: number; // total call count
 }
 

--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -41,6 +41,11 @@ export interface Category {
   name: string;
 }
 
+export class CategoryMap {
+  category: Category;
+  issues: Issue[];
+}
+
 export type Party = 'Democrat' | 'Republican' | 'Independent' | '';
 
 // export const DefaultContact: Contact = {

--- a/src/components/call/CallPageContainer.tsx
+++ b/src/components/call/CallPageContainer.tsx
@@ -61,8 +61,10 @@ interface DispatchProps {
 */
 const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProps => {
   let currentIssue: Issue | undefined = undefined;
-  if (state.remoteDataState.issues) {
-    currentIssue = state.remoteDataState.issues.find(i => i.id === ownProps.match.params.id);
+  if (state.remoteDataState.issues && state.remoteDataState.inactiveIssues) {
+    currentIssue = state.remoteDataState.issues
+                   .concat(state.remoteDataState.inactiveIssues)
+                   .find(i => i.id === ownProps.match.params.id);
   }
 
   return {

--- a/src/components/done/Done.tsx
+++ b/src/components/done/Done.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import i18n from '../../services/i18n';
 import { TranslationFunction } from 'i18next';
 import { translate, Trans } from 'react-i18next';
 import { Issue } from '../../common/model';
@@ -23,7 +22,7 @@ export const Done: React.StatelessComponent<Props> = (props: Props) => {
         </p>
         <Promotion
           currentIssue={props.currentIssue}
-          t={i18n.t}
+          t={props.t}
         />
         <p className="call__text">
           <Trans i18nKey="callComplete.learnWhyCallingIsGreat">
@@ -34,7 +33,7 @@ export const Done: React.StatelessComponent<Props> = (props: Props) => {
 
         <CallCount
           totalCount={props.totalCount}
-          t={i18n.t}
+          t={props.t}
         />
       </div>
     </section>

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -28,6 +28,11 @@ export const IssuesList: React.StatelessComponent<Props> = (props: Props) => {
           isIssueActive={currentIssueId === issue.id}
           onSelectIssue={props.onSelectIssue}
         />) : <div style={{ textAlign: 'center' }}>{props.t('noCalls.title')}</div>}
+      <li>
+        <a href="/more" className="issues__footer-link">
+          <span>{props.t('issues.viewAllActiveIssues')}</span>
+        </a>
+      </li>
     </ul>
   );
 };

--- a/src/components/issues/MoreIssues.tsx
+++ b/src/components/issues/MoreIssues.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { TranslationFunction } from 'i18next';
 import { translate } from 'react-i18next';
 import { Issue, CategoryMap } from '../../common/model';
-import { IssuesListItem } from './index'
+import { IssuesListItem } from './index';
 
 interface Props {
   readonly inactiveIssues: Issue[];
   readonly categoryMap: CategoryMap[];
-  readonly totalCount: number;
+  readonly completedIssueIds: string[];
   readonly t: TranslationFunction;
   readonly onSelectIssue: (issueId: string) => Function;  
 }
@@ -17,7 +17,7 @@ export const MoreIssues: React.StatelessComponent<Props> = (props: Props) => {
     <section className="call">
     <div className="call_complete">
       <h2 className="call__title">
-        {props.t('issues.activeIssuesWithCount', {count: 10})}
+        {props.t('issues.activeIssuesWithCount', {count: (props.inactiveIssues ? props.inactiveIssues.length : 0)})}
       </h2>
       {props.categoryMap ? props.categoryMap.map((cat, key) =>
         <div key={key}>
@@ -27,14 +27,17 @@ export const MoreIssues: React.StatelessComponent<Props> = (props: Props) => {
             <IssuesListItem
               key={issue.id}
               issue={issue}
-              isIssueComplete={false}
+              isIssueComplete={
+                props.completedIssueIds &&
+                (props.completedIssueIds.find((issueId: string) => issue.id === issueId) !== undefined)
+              }
               isIssueActive={false}
               onSelectIssue={props.onSelectIssue}
             />
           )}
           </ul>
         </div>
-      ): <span/>}
+      ) : <span/> }
     </div>
     </section>
   );

--- a/src/components/issues/MoreIssues.tsx
+++ b/src/components/issues/MoreIssues.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { TranslationFunction } from 'i18next';
+import { translate } from 'react-i18next';
+import { Issue, CategoryMap } from '../../common/model';
+import { IssuesListItem } from './index'
+
+interface Props {
+  readonly inactiveIssues: Issue[];
+  readonly categoryMap: CategoryMap[];
+  readonly totalCount: number;
+  readonly t: TranslationFunction;
+  readonly onSelectIssue: (issueId: string) => Function;  
+}
+
+export const MoreIssues: React.StatelessComponent<Props> = (props: Props) => {
+  return (
+    <section className="call">
+    <div className="call_complete">
+      <h2 className="call__title">
+        {props.t('issues.activeIssuesWithCount', {count: 10})}
+      </h2>
+      {props.categoryMap ? props.categoryMap.map((cat, key) =>
+        <div key={key}>
+          <h2>{cat.category.name}</h2>
+          <ul className="issues-list" role="navigation">
+          {cat.issues.map((issue) =>
+            <IssuesListItem
+              key={issue.id}
+              issue={issue}
+              isIssueComplete={false}
+              isIssueActive={false}
+              onSelectIssue={props.onSelectIssue}
+            />
+          )}
+          </ul>
+        </div>
+      ): <span/>}
+    </div>
+    </section>
+  );
+};
+
+export const MoreIssuesTranslatable = translate()(MoreIssues);

--- a/src/components/issues/MoreIssuesContainer.tsx
+++ b/src/components/issues/MoreIssuesContainer.tsx
@@ -1,0 +1,39 @@
+import { connect, Dispatch } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { ApplicationState } from '../../redux/root';
+import { MoreIssuesPage } from './index';
+import { Issue } from '../../common/model';
+import { getIssuesIfNeeded } from '../../redux/remoteData';
+import { selectIssueActionCreator } from '../../redux/callState';
+
+import { RouteComponentProps } from 'react-router-dom';
+
+interface OwnProps extends RouteComponentProps<{ id: string }> { }
+
+interface StateProps {
+  readonly issues: Issue[];
+  readonly totalCount: number;
+}
+
+interface DispatchProps {
+  readonly onSelectIssue: (issueId: string) => void;
+  readonly onGetIssuesIfNeeded: () => void;
+}
+
+const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProps => {
+  return {
+    issues: state.remoteDataState.inactiveIssues,
+    totalCount: state.remoteDataState.callTotal,
+  };
+};
+
+const mapDispatchToProps = (dispatch: Dispatch<ApplicationState>): DispatchProps => {
+  return bindActionCreators(
+    {
+      onSelectIssue: selectIssueActionCreator,
+      onGetIssuesIfNeeded: getIssuesIfNeeded,
+    },
+    dispatch);
+};
+
+export default connect<StateProps, DispatchProps, OwnProps>(mapStateToProps, mapDispatchToProps)(MoreIssuesPage as any);

--- a/src/components/issues/MoreIssuesContainer.tsx
+++ b/src/components/issues/MoreIssuesContainer.tsx
@@ -12,18 +12,25 @@ interface OwnProps extends RouteComponentProps<{ id: string }> { }
 
 interface StateProps {
   readonly issues: Issue[];
-  readonly totalCount: number;
+  readonly currentIssue?: Issue;  
+  readonly completedIssueIds: string[];
 }
 
-interface DispatchProps {
+interface DispatchProps { 
   readonly onSelectIssue: (issueId: string) => void;
   readonly onGetIssuesIfNeeded: () => void;
 }
 
 const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProps => {
+  let currentIssue: Issue | undefined = undefined;
+  if (state.remoteDataState.issues) {
+    currentIssue = state.remoteDataState.issues.find(i => i.id === ownProps.match.params.id);
+  }
+
   return {
     issues: state.remoteDataState.inactiveIssues,
-    totalCount: state.remoteDataState.callTotal,
+    currentIssue: currentIssue,
+    completedIssueIds: state.callState.completedIssueIds,
   };
 };
 
@@ -36,4 +43,4 @@ const mapDispatchToProps = (dispatch: Dispatch<ApplicationState>): DispatchProps
     dispatch);
 };
 
-export default connect<StateProps, DispatchProps, OwnProps>(mapStateToProps, mapDispatchToProps)(MoreIssuesPage as any);
+export default connect<StateProps, DispatchProps, OwnProps>(mapStateToProps, mapDispatchToProps)(MoreIssuesPage);

--- a/src/components/issues/MoreIssuesPage.tsx
+++ b/src/components/issues/MoreIssuesPage.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import i18n from '../../services/i18n';
+import { RouteComponentProps } from 'react-router-dom';
+import { LayoutContainer } from '../layout';
+import { Issue, Category, CategoryMap } from '../../common/model';
+import { MoreIssuesTranslatable } from './index';
+
+interface RouteProps extends RouteComponentProps<{ id: string }> { }
+
+interface Props extends RouteProps {
+  readonly issues: Issue[];
+  readonly totalCount: number;
+  readonly onSelectIssue: (issueId: string) => Function;
+  readonly onGetIssuesIfNeeded: () => Function;
+}
+
+export interface State {
+  issueCategoryMap: CategoryMap[];
+}
+
+class MoreIssuesPage extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    // set initial state
+    this.state = this.setStateFromProps(props);
+  }
+
+  setStateFromProps(props: Props): State {
+    let categoryMap: CategoryMap[] = [];
+
+    if (props.issues) {
+      props.issues.forEach((issue) => {
+        let category: string = 'uncategorized';
+
+        if (issue.categories[0]) {
+          category = issue.categories[0].name;
+
+          let availableMap;
+          categoryMap.forEach((map) => {
+            if (map.category.name == category) {
+              availableMap = map
+            }
+          })
+
+          if (availableMap) {
+            availableMap.issues.push(issue);
+          } else {
+            let newCategory: Category = {name: category};
+            let newCategoryMap: CategoryMap = {category: newCategory, issues: [issue] };
+            categoryMap.push(newCategoryMap);
+          }
+        }
+      });  
+    }
+
+    return {
+      issueCategoryMap: categoryMap,
+    };
+  }
+
+  componentWillReceiveProps(newProps: Props) {
+    this.setState(this.setStateFromProps(newProps));
+  }
+
+  componentDidMount() {
+    this.props.onGetIssuesIfNeeded();
+  }
+
+  render() {
+    return (
+      <LayoutContainer issueId={this.props.match.params.id}>
+        <main role="main" id="content" className="layout__main">
+          <MoreIssuesTranslatable
+            inactiveIssues={this.props.issues}
+            categoryMap={this.state.issueCategoryMap}
+            totalCount={this.props.totalCount}
+            t={i18n.t}
+            onSelectIssue={this.props.onSelectIssue}
+          />
+        </main>
+      </LayoutContainer>
+    );
+  }
+}
+
+export default MoreIssuesPage;

--- a/src/components/issues/index.ts
+++ b/src/components/issues/index.ts
@@ -4,4 +4,5 @@ import MoreIssuesPage from './MoreIssuesPage';
 import { MoreIssues, MoreIssuesTranslatable } from './MoreIssues';
 import MoreIssuesContainer from './MoreIssuesContainer';
 
-export { IssuesList, IssuesListTranslatable, IssuesListItem, MoreIssuesPage, MoreIssues, MoreIssuesTranslatable, MoreIssuesContainer };
+export { IssuesList, IssuesListTranslatable, IssuesListItem, MoreIssuesPage, 
+         MoreIssues, MoreIssuesTranslatable, MoreIssuesContainer };

--- a/src/components/issues/index.ts
+++ b/src/components/issues/index.ts
@@ -1,4 +1,7 @@
 import { IssuesList, IssuesListTranslatable } from './IssuesList';
 import IssuesListItem from './IssuesListItem';
+import MoreIssuesPage from './MoreIssuesPage';
+import { MoreIssues, MoreIssuesTranslatable } from './MoreIssues';
+import MoreIssuesContainer from './MoreIssuesContainer';
 
-export { IssuesList, IssuesListTranslatable, IssuesListItem };
+export { IssuesList, IssuesListTranslatable, IssuesListItem, MoreIssuesPage, MoreIssues, MoreIssuesTranslatable, MoreIssuesContainer };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import { HomePageContainer } from './components/home';
 import { AboutPage } from './components/about';
 import { FaqPage } from './components/faq';
 import { DonePageContainer } from './components/done';
+import { MoreIssuesContainer } from './components/issues';
 import { CallPageContainer } from './components/call';
 import './components/bundle.css';
 import './components/shared/scss/style.css';
@@ -31,6 +32,7 @@ ReactDOM.render(
           <Route path="/" exact={true} component={HomePageContainer} />
           <Route path="/issue/:id" exact={true} component={CallPageContainer} />
           <Route path="/done/:id" exact={true} component={DonePageContainer} />
+          <Route path="/more" exact={true} component={MoreIssuesContainer} />
           <Route path="/faq" exact={true} component={FaqPage} />
           <Route path="/about" exact={true} component={AboutPage} />
           <Route path="*" component={HomePageContainer} />

--- a/src/redux/location/asyncActionCreator.ts
+++ b/src/redux/location/asyncActionCreator.ts
@@ -1,12 +1,12 @@
 import { Dispatch } from 'redux';
-import { getApiData } from '../../redux/remoteData';
+import { fetchAllIssues } from '../../redux/remoteData';
 import { setLocation, setUiState } from './index';
 import { ApplicationState } from '../root';
 import { LocationUiState } from '../../common/model';
 
 export function setAddress(address: string) {
   return (dispatch: Dispatch<ApplicationState>) => {
-    return dispatch(getApiData(address))
+    return dispatch(fetchAllIssues(address))
       .then(() => {
         dispatch(setLocation(address));
       });
@@ -15,7 +15,7 @@ export function setAddress(address: string) {
 
 export function newLocationLookup(location: string) {
   return (dispatch: Dispatch<ApplicationState>) => {
-    return dispatch(getApiData(location))
+    return dispatch(fetchAllIssues(location))
       .then(() => {
         dispatch(setUiState(LocationUiState.LOCATION_FOUND));
       })

--- a/src/redux/remoteData/action.ts
+++ b/src/redux/remoteData/action.ts
@@ -2,11 +2,11 @@ import { RemoteDataAction } from './action';
 import { Action } from 'redux';
 import { Issue } from '../../common/model';
 
-export type RemoteDataActionType =
-  'GET_ISSUES' |
-  'GET_CALL_TOTAL' |
-  'API_ERROR'
-  ;
+export enum RemoteDataActionType {
+  GET_ISSUES = 'GET_ISSUES',
+  GET_CALL_TOTAL = 'GET_CALL_TOTAL',
+  API_ERROR = 'API_ERROR',
+}
 
 export interface RemoteDataAction extends  Action {
   type: RemoteDataActionType;
@@ -14,16 +14,16 @@ export interface RemoteDataAction extends  Action {
 }
 
 export interface IssuesAction extends RemoteDataAction {
-  type: 'GET_ISSUES';
+  type: RemoteDataActionType.GET_ISSUES;
   payload: Issue[];
 }
 
 export interface CallCountAction extends RemoteDataAction {
-  type: 'GET_CALL_TOTAL';
+  type: RemoteDataActionType.GET_CALL_TOTAL;
   payload: number;
 }
 
 export interface ApiErrorAction extends RemoteDataAction {
-  type: 'API_ERROR';
+  type: RemoteDataActionType.API_ERROR;
   payload: string;
 }

--- a/src/redux/remoteData/actionCreator.ts
+++ b/src/redux/remoteData/actionCreator.ts
@@ -1,25 +1,25 @@
 import { NewLocationLookupAction, LocationActionType } from './../location/index';
 import { CallCountAction, ApiErrorAction } from './index';
 import { Issue } from '../../common/model';
-import { IssuesAction } from './index';
+import { IssuesAction, RemoteDataActionType } from './index';
 
 export const issuesActionCreator = (issues: Issue[]): IssuesAction => {
   return {
-    type: 'GET_ISSUES',
+    type: RemoteDataActionType.GET_ISSUES,
     payload: issues
   };
 };
 
 export const callCountActionCreator = (callTotal: number): CallCountAction => {
   return {
-    type: 'GET_CALL_TOTAL',
+    type: RemoteDataActionType.GET_CALL_TOTAL,
     payload: callTotal
   };
 };
 
 export const apiErrorMessageActionCreator = (message: string): ApiErrorAction => {
   return {
-    type: 'API_ERROR',
+    type: RemoteDataActionType.API_ERROR,
     payload: message
   };
 };

--- a/src/redux/remoteData/asyncActionCreator.test.ts
+++ b/src/redux/remoteData/asyncActionCreator.test.ts
@@ -2,7 +2,7 @@ import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import * as moxios from 'moxios';
 import { RemoteDataActionType } from './action';
-import { fetchCallCount, getApiData, fetchLocationByIP } from './index';
+import { fetchCallCount, fetchAllIssues, fetchLocationByIP } from './index';
 import { ApplicationState } from './../root';
 import { ApiData, DefaultIssue, IpInfoData, LocationFetchType, LocationUiState } from './../../common/model';
 import * as Constants from '../../common/constants';
@@ -35,7 +35,7 @@ test('getApiData() action creator functions correctly', () => {
   };
   initialState.locationState = locationState;
   const store = mockStore(initialState);
-  store.dispatch(getApiData(address))
+  store.dispatch(fetchAllIssues(address))
     .then(() => {
       const actions = store.getActions();
       // console.log('Actions', actions);
@@ -83,7 +83,7 @@ test.skip('fetchLocationByIP() action creator works correctly', () => {
 
 test('fetchCallCount() action creator dispatches proper action', () => {
   const count = 999999;
-  const expectedType: RemoteDataActionType = 'GET_CALL_TOTAL';
+  const expectedType: RemoteDataActionType = RemoteDataActionType.GET_CALL_TOTAL;
   moxios.stubRequest(/report/, { response: { count} });
   const initialState = {} as ApplicationState;
   const store = mockStore(initialState);

--- a/src/redux/remoteData/asyncActionCreator.ts
+++ b/src/redux/remoteData/asyncActionCreator.ts
@@ -1,6 +1,6 @@
 import { Dispatch } from 'redux';
-import { ApiData, IpInfoData, LocationFetchType, ReportData } from './../../common/model';
-import { getAllIssues, getReportData } from '../../services/apiServices';
+import { ApiData, IpInfoData, LocationFetchType, CountData } from './../../common/model';
+import { getAllIssues, getCountData } from '../../services/apiServices';
 import { setCachedCity, setLocation, setLocationFetchType,
   setSplitDistrict, setUiState } from '../location/index';
 import { getLocationByIP, getBrowserGeolocation, GEOLOCATION_TIMEOUT } from '../../services/geolocationServices';
@@ -55,8 +55,8 @@ export const fetchAllIssues = (address: string = '') => {
 export const fetchCallCount = () => {
   return (dispatch: Dispatch<ApplicationState>,
           getState: () => ApplicationState) => {
-    return getReportData()
-      .then((response: ReportData) => {
+    return getCountData()
+      .then((response: CountData) => {
         dispatch(callCountActionCreator(response.count));
         // tslint:disable-next-line:no-console
       }).catch((error) => console.error(`fetchCallCount error: ${error.message}`, error));

--- a/src/redux/remoteData/index.ts
+++ b/src/redux/remoteData/index.ts
@@ -3,5 +3,5 @@ export { IssuesAction, RemoteDataAction, RemoteDataActionType,
 export { issuesActionCreator, callCountActionCreator,
   apiErrorMessageActionCreator } from './actionCreator';
 export { RemoteDataState, remoteDataReducer } from './reducer';
-export { startup, getApiData, getIssuesIfNeeded, fetchCallCount,
-  fetchLocationByIP, fetchBrowserGeolocation } from './asyncActionCreator';
+export { startup, fetchAllIssues, getIssuesIfNeeded,
+   fetchCallCount, fetchLocationByIP, fetchBrowserGeolocation } from './asyncActionCreator';

--- a/src/redux/remoteData/reducer.test.ts
+++ b/src/redux/remoteData/reducer.test.ts
@@ -1,5 +1,5 @@
 import { DefaultIssue } from './../../common/model';
-import { RemoteDataState, remoteDataReducer, IssuesAction,
+import { RemoteDataState, RemoteDataActionType, remoteDataReducer, IssuesAction,
   CallCountAction, ApiErrorAction } from './index';
 
 let defaultState;
@@ -16,7 +16,7 @@ test('Remote Data reducer processes GET_ISSUES action correctly', () => {
   const state: RemoteDataState =
     Object.assign({}, defaultState, issues);
   const action: IssuesAction = {
-    type: 'GET_ISSUES',
+    type: RemoteDataActionType.GET_ISSUES,
     payload: issues
   };
   const newState = remoteDataReducer(state, action);
@@ -28,7 +28,7 @@ test('Remote Data reducer processes GET_CALL_TOTAL action correctly', () => {
   const state: RemoteDataState =
     Object.assign({}, defaultState, callTotal);
   const action: CallCountAction = {
-    type: 'GET_CALL_TOTAL',
+    type: RemoteDataActionType.GET_CALL_TOTAL,
     payload: callTotal
   };
   const newState = remoteDataReducer(state, action);
@@ -40,7 +40,7 @@ test('Remote Data reducer processes API_ERROR action correctly', () => {
   const state: RemoteDataState =
     Object.assign({}, defaultState, errorMessage);
   const action: ApiErrorAction = {
-    type: 'API_ERROR',
+    type: RemoteDataActionType.API_ERROR,
     payload: errorMessage
   };
   const newState = remoteDataReducer(state, action);

--- a/src/redux/remoteData/reducer.ts
+++ b/src/redux/remoteData/reducer.ts
@@ -1,9 +1,10 @@
 import { Reducer } from 'redux';
 import { Issue } from '../../common/model';
-import { RemoteDataAction } from './index';
+import { RemoteDataAction, RemoteDataActionType } from './index';
 
 export interface RemoteDataState {
   issues: Issue[];
+  inactiveIssues: Issue[];
   callTotal: number;
   errorMessage: string;
 }
@@ -12,12 +13,21 @@ export const remoteDataReducer: Reducer<RemoteDataState> = (
   state: RemoteDataState = {} as RemoteDataState,
   action: RemoteDataAction): RemoteDataState => {
   switch (action.type) {
-    case 'GET_ISSUES':
-      const newState = Object.assign({}, state, {issues: action.payload});
-      return newState;
-    case 'GET_CALL_TOTAL':
+    case RemoteDataActionType.GET_ISSUES:
+      // filter all issues into active / inactive
+      let activeIssues: Issue[] = [];
+      let inactiveIssues: Issue[] = [];
+      if (action !== undefined && action.payload !== undefined) {
+        let issues = action.payload as Issue[];
+        activeIssues = issues.filter((item) => { return item.inactive === false; });
+        inactiveIssues = issues.filter((item) => { return item.inactive === true; });
+      }
+
+      const issuesState = Object.assign({}, state, {issues: activeIssues, inactiveIssues: inactiveIssues});
+      return issuesState;
+    case RemoteDataActionType.GET_CALL_TOTAL:
       return Object.assign({}, state, {callTotal: action.payload});
-    case 'API_ERROR':
+    case RemoteDataActionType.API_ERROR:
       return Object.assign({}, state, {errorMessage: action.payload});
     default:
       return state;

--- a/src/services/apiServices.ts
+++ b/src/services/apiServices.ts
@@ -1,7 +1,7 @@
 import { OutcomeData } from './../redux/callState/asyncActionCreator';
 import axios from 'axios';
 import * as querystring from 'querystring';
-import { ApiData, ReportData } from './../common/model';
+import { ApiData, CountData } from './../common/model';
 import * as Constants from '../common/constants';
 
 export const getAllIssues = (address: string): Promise<ApiData> => {
@@ -10,8 +10,8 @@ export const getAllIssues = (address: string): Promise<ApiData> => {
     .catch(e => Promise.reject(e));
 };
 
-export const getReportData = (): Promise<ReportData> => {
-  return axios.get(`${Constants.REPORT_API_URL}`)
+export const getCountData = (): Promise<CountData> => {
+  return axios.get(`${Constants.COUNTS_API_URL}`)
     .then(response => Promise.resolve(response.data))
     .catch(e => Promise.reject(e));
 };

--- a/src/services/apiServices.ts
+++ b/src/services/apiServices.ts
@@ -26,7 +26,7 @@ export const postOutcomeData = (data: OutcomeData) => {
   });
   // console.log('postOutcomeData() posted data:', postData)
   return axios.post(
-      `${Constants.REGISTER_CALL_API_URL}`,
+      `${Constants.REPORT_API_URL}`,
       postData,
       {
         headers: {'Content-Type': 'application/x-www-form-urlencoded'}

--- a/src/services/apiServices.ts
+++ b/src/services/apiServices.ts
@@ -4,7 +4,7 @@ import * as querystring from 'querystring';
 import { ApiData, ReportData } from './../common/model';
 import * as Constants from '../common/constants';
 
-export const get5CallsApiData = (address: string): Promise<ApiData> => {
+export const getAllIssues = (address: string): Promise<ApiData> => {
   return axios.get(`${Constants.ISSUES_API_URL}${encodeURIComponent(address)}`)
     .then(response => Promise.resolve(response.data))
     .catch(e => Promise.reject(e));


### PR DESCRIPTION
From issue #16 

This one was harder than I thought, but I ended up making an improvement to the backend I like as well.

* backend now (well, later tonight) supports a parameter `all=true` which returns all issues with an `inactive` property. Get all the issues at once, then figure out where they belong on the frontend.
* `MoreIssuesContainer` is basically the same as `DoneIssueContainer`... I don't know exactly how we want to manage this growing number of containers that are mostly the same stuff. Do we make all of them `LayoutContainer` and then add all the data one could ever need in them?
* Selecting issues doesn't work from the inactive issues list. It looks like all the right messages are being sent and the URL changes, I don't know what I'm doing wrong here...