### PR TITLE
Fixes user entered blank address bug

### DIFF
--- a/src/redux/remoteData/asyncActionCreator.ts
+++ b/src/redux/remoteData/asyncActionCreator.ts
@@ -31,11 +31,10 @@ export const getIssuesIfNeeded = () => {
 export const fetchAllIssues = (address: string = '') => {
   return (dispatch: Dispatch<ApplicationState>,
           getState: () => ApplicationState) => {
-    // console.log('getApiData start');
     return getAllIssues(address)
       .then((response: ApiData) => {
-        // console.log('getApiData then() response', response);
-        if (response.invalidAddress) {
+        if (!address || response.invalidAddress) {
+          dispatch(setUiState(LocationUiState.LOCATION_ERROR));
           throw new Error('Invalid address found');
         }
         const normalizedAddress = response.normalizedLocation as string;


### PR DESCRIPTION
When a user does not enter a location and clicks the 'Go' button, the result is a UI with a 'Your location' title (and no location noted) and the 'Change location' button visible. This PR fixes that: When no address is entered, the location title says 'That address is invalid, please try again' and the location text box and 'Go' button is visible to allow the user to enter a valid location.

This branch was originally designed to fix issue #35, but I could not replicate that bug.