### PR TITLE
Support for custom issue lists for groups

### DIFF
--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -114,6 +114,14 @@ export interface ApiData {
   issues: Issue[];
 }
 
+export interface GroupIssues {
+  splitDistrict: boolean;
+  invalidAddress: boolean;
+  normalizedLocation: string | undefined;
+  divisions: string[];
+  issues: Issue[];
+}
+
 export interface CountData {
   count: number; // total call count
 }

--- a/src/components/call/Call.test.tsx
+++ b/src/components/call/Call.test.tsx
@@ -27,7 +27,6 @@ test('Call component should be rendered if passed a valid object', () => {
     <Call
       issue={issue}
       callState={callState}
-      splitDistrict={false}
       clearLocation={clearLocation}
       locationState={locationState}
       t={i18n.t}

--- a/src/components/call/Call.tsx
+++ b/src/components/call/Call.tsx
@@ -12,11 +12,10 @@ import { LocationState } from '../../redux/location/reducer';
 export interface Props {
   readonly issue: Issue;
   readonly callState: CallState;
+  readonly locationState: LocationState;
   readonly t: TranslationFunction;
-  readonly splitDistrict: boolean;
   readonly clearLocation: () => void;
   readonly onSubmitOutcome: (data: OutcomeData) => Function;
-  readonly locationState: LocationState;
 }
 
 export interface State {
@@ -72,9 +71,9 @@ export class Call extends React.Component<Props, State> {
           currentIssue={this.state.issue}
           t={i18n.t}
         />
-        {this.props.splitDistrict ?
+        {this.props.locationState.splitDistrict ?
         <NoContactSplitDistrict
-          splitDistrict={this.props.splitDistrict}
+          splitDistrict={this.props.locationState.splitDistrict}
           clearLocation={this.props.clearLocation}
           t={i18n.t}
         /> :
@@ -89,7 +88,7 @@ export class Call extends React.Component<Props, State> {
           locationState={this.props.locationState}
           t={i18n.t}
         />
-        {this.props.splitDistrict || 
+        {this.props.locationState.splitDistrict || 
          this.props.issue && 
          (this.props.issue.contacts && this.props.issue.contacts.length === 0) ? <span/> :
         <Outcomes
@@ -100,7 +99,7 @@ export class Call extends React.Component<Props, State> {
           t={i18n.t}
         />}
         {/* TODO: Fix people/person text for 1 contact left. Move logic to a function */}
-        {this.props.splitDistrict ? <span/> :
+        {this.props.locationState.splitDistrict ? <span/> :
         this.state.numberContactsLeft > 0 ?
           <h3 aria-live="polite" className="call__contacts__left" >
             {this.props.t('outcomes.contactsLeft', { contactsRemaining: this.state.numberContactsLeft })}

--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -3,9 +3,10 @@ import i18n from '../../services/i18n';
 import { RouteComponentProps } from 'react-router-dom';
 import { CallTranslatable } from './index';
 import { LayoutContainer } from '../layout';
-import { Issue } from '../../common/model';
+import { Issue, Group } from '../../common/model';
 import { CallState, OutcomeData } from '../../redux/callState';
 import { LocationState } from '../../redux/location/reducer';
+import { queueUntilHydration } from '../../redux/rehydrationUtil';
 
 /*
   This is the top level View component in the CallPage Component Hierarchy.  It is the
@@ -33,18 +34,22 @@ import { LocationState } from '../../redux/location/reducer';
     it in our route.  In this route "/call/:id" (as well as the "/done/:id" route), we've defined
     our params to have simply one key: "id".
 */
-interface RouteProps extends RouteComponentProps<{ id: string }> { }
+
+// feels a bit smelly to do <any> here but the route could either be normal { id } or group { groupid, issueid }
+// but we don't actually use this below, we just need it for types, so...?
+// tslint:disable-next-line:no-any
+interface RouteProps extends RouteComponentProps<any> { }
 
 interface Props extends RouteProps {
   readonly issues: Issue[];
+  readonly currentIssue: Issue;
+  readonly activeGroup?: Group;
   readonly callState: CallState;
   readonly locationState: LocationState;
-  readonly currentIssue: Issue;
-  readonly splitDistrict: boolean;
   readonly onSubmitOutcome: (data: OutcomeData) => Function;
   readonly onSelectIssue: (issueId: string) => Function;
-  readonly clearLocation: () => void;
   readonly onGetIssuesIfNeeded: () => Function;
+  readonly clearLocation: () => void;
 }
 
 export interface State {
@@ -99,10 +104,12 @@ class CallPage extends React.Component<Props, State> {
       // On the first render, if the issues haven't been loaded(came here directly, not first to home page)
       // here we'll check to see if issues are in the redux store and if not we'll load them
       // if we have to load them, the component will be re-rendered after the issues are retrieved
-      this.props.onGetIssuesIfNeeded();
+      queueUntilHydration(() => {
+        this.props.onGetIssuesIfNeeded();
+      });
     } else {
       // this is the case where the user has clicked on an issue from the sidebar
-      if (!this.props.callState.currentIssueId) {
+      if (!this.props.callState.currentIssueId && this.props.currentIssue) {
         this.props.onSelectIssue(this.props.currentIssue.id);
       }
     }
@@ -110,14 +117,17 @@ class CallPage extends React.Component<Props, State> {
 
   getView() {
     return (
-      <LayoutContainer issueId={this.props.currentIssue ? this.props.currentIssue.id : undefined} >
+      <LayoutContainer
+        issues={this.props.issues}
+        issueId={this.props.currentIssue ? this.props.currentIssue.id : undefined}
+        currentGroup={this.props.activeGroup ? this.props.activeGroup.id : undefined}
+      >
         <CallTranslatable
           issue={this.props.currentIssue}
           callState={this.props.callState}
           locationState={this.props.locationState}
           clearLocation={this.props.clearLocation}
           onSubmitOutcome={this.props.onSubmitOutcome}
-          splitDistrict={this.props.splitDistrict}
           t={i18n.t}
         />
       </LayoutContainer>

--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -6,7 +6,7 @@ import { LayoutContainer } from '../layout';
 import { Issue, Group } from '../../common/model';
 import { CallState, OutcomeData } from '../../redux/callState';
 import { LocationState } from '../../redux/location/reducer';
-import { queueUntilHydration } from '../../redux/rehydrationUtil';
+import { queueUntilRehydration } from '../../redux/rehydrationUtil';
 
 /*
   This is the top level View component in the CallPage Component Hierarchy.  It is the
@@ -104,7 +104,7 @@ class CallPage extends React.Component<Props, State> {
       // On the first render, if the issues haven't been loaded(came here directly, not first to home page)
       // here we'll check to see if issues are in the redux store and if not we'll load them
       // if we have to load them, the component will be re-rendered after the issues are retrieved
-      queueUntilHydration(() => {
+      queueUntilRehydration(() => {
         this.props.onGetIssuesIfNeeded();
       });
     } else {

--- a/src/components/call/CallPageContainer.tsx
+++ b/src/components/call/CallPageContainer.tsx
@@ -62,7 +62,7 @@ interface DispatchProps {
  the object with the props (see the Call page for an example).
 */
 const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProps => {
-  const currentIssue: Issue | undefined = getIssue(state, ownProps.match.params.id);
+  const currentIssue: Issue | undefined = getIssue(state.remoteDataState, ownProps.match.params.id);
 
   return {
     currentIssue: currentIssue,

--- a/src/components/call/CallPageContainer.tsx
+++ b/src/components/call/CallPageContainer.tsx
@@ -39,11 +39,9 @@ interface OwnProps extends RouteComponentProps<{ id: string }> { }
 
 // This defines the data that we will pull off the Redux store
 interface StateProps {
-  readonly callState: CallState;
   readonly currentIssue?: Issue;
-  readonly splitDistrict: boolean;
+  readonly callState: CallState;
   readonly locationState: LocationState;
-
 }
 
 /*
@@ -67,9 +65,8 @@ const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProp
   const currentIssue: Issue | undefined = getIssue(state, ownProps.match.params.id);
 
   return {
-    callState: state.callState,
     currentIssue: currentIssue,
-    splitDistrict: state.locationState.splitDistrict, // todo: just pass locationState and remove separate splitDistrict
+    callState: state.callState,
     locationState: state.locationState
   };
 };

--- a/src/components/call/__snapshots__/Call.test.tsx.snap
+++ b/src/components/call/__snapshots__/Call.test.tsx.snap
@@ -221,7 +221,6 @@ ShallowWrapper {
                       }
         }
         onSubmitOutcome={[Function]}
-        splitDistrict={false}
         t={[Function]}
 />,
       "_debugID": 1,
@@ -263,7 +262,6 @@ ShallowWrapper {
             "uiState": "LOCATION_FOUND",
           },
           "onSubmitOutcome": [Function],
-          "splitDistrict": false,
           "t": [Function],
         },
         "refs": Object {},
@@ -518,7 +516,6 @@ ShallowWrapper {
           }
     }
     onSubmitOutcome={[Function]}
-    splitDistrict={false}
     t={[Function]}
 />,
 }

--- a/src/components/done/DonePageContainer.tsx
+++ b/src/components/done/DonePageContainer.tsx
@@ -24,7 +24,7 @@ interface DispatchProps {
 }
 
 const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProps => {
-  const currentIssue: Issue | undefined = getIssue(state, ownProps.match.params.id);
+  const currentIssue: Issue | undefined = getIssue(state.remoteDataState, ownProps.match.params.id);
 
   return {
     issues: state.remoteDataState.issues,

--- a/src/components/groups/GroupCallPageContainer.tsx
+++ b/src/components/groups/GroupCallPageContainer.tsx
@@ -30,7 +30,7 @@ interface DispatchProps {
 
 const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProps => {
   let groupPageIssues: Issue[] = [];
-  
+
   // send group issues if they exist, normal active ones if they don't
   if (state.remoteDataState.groupIssues && state.remoteDataState.groupIssues.length !== 0) {
     groupPageIssues = state.remoteDataState.groupIssues;
@@ -38,8 +38,8 @@ const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProp
     groupPageIssues = state.remoteDataState.issues;
   }
 
-  const currentIssue: Issue | undefined = getIssue(state, ownProps.match.params.issueid);
-  
+  const currentIssue: Issue | undefined = getIssue(state.remoteDataState, ownProps.match.params.issueid);
+
   return {
     activeGroup: state.callState.group,
     issues: groupPageIssues,

--- a/src/components/groups/GroupCallPageContainer.tsx
+++ b/src/components/groups/GroupCallPageContainer.tsx
@@ -1,56 +1,68 @@
 import { connect, Dispatch } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { ApplicationState } from '../../redux/root';
-import GroupPage from './GroupPage';
-import { Group, Issue } from '../../common/model';
+import { CallPage } from '../call/index';
+import { Issue, Group } from '../../common/model';
+import { getIssue } from '../shared/utils';
 import { getGroupIssuesIfNeeded } from '../../redux/remoteData';
 import { LocationState } from '../../redux/location/reducer';
-import { CallState } from '../../redux/callState/reducer';
-import { selectIssueActionCreator, joinGroupActionCreator } from '../../redux/callState';
+import { CallState, OutcomeData, submitOutcome, selectIssueActionCreator } from '../../redux/callState';
+import { clearAddress } from '../../redux/location';
 
 import { RouteComponentProps } from 'react-router-dom';
 
 interface OwnProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 
 interface StateProps {
-  readonly activeGroup?: Group;
   readonly issues: Issue[];
+  readonly currentIssue?: Issue;
+  readonly activeGroup?: Group;
   readonly callState: CallState;
   readonly locationState: LocationState;
 }
 
 interface DispatchProps {
+  readonly onSubmitOutcome: (data: OutcomeData) => void;
+  readonly onGetIssuesIfNeeded: () => void;
   readonly onSelectIssue: (issueId: string) => void;
-  readonly onGetIssuesIfNeeded: (groupid: string) => void;
-  readonly onJoinGroup: (group: Group) => void;
+  readonly clearLocation: () => void;
 }
 
 const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProps => {
   let groupPageIssues: Issue[] = [];
-
+  
   // send group issues if they exist, normal active ones if they don't
   if (state.remoteDataState.groupIssues && state.remoteDataState.groupIssues.length !== 0) {
     groupPageIssues = state.remoteDataState.groupIssues;
   } else {
     groupPageIssues = state.remoteDataState.issues;
   }
+
+  const currentIssue: Issue | undefined = getIssue(state, ownProps.match.params.issueid);
   
   return {
     activeGroup: state.callState.group,
     issues: groupPageIssues,
+    currentIssue: currentIssue,
     callState: state.callState,
     locationState: state.locationState,
   };
 };
 
-const mapDispatchToProps = (dispatch: Dispatch<ApplicationState>): DispatchProps => {
+const mapDispatchToProps = (dispatch: Dispatch<ApplicationState>, ownProps: OwnProps): DispatchProps => {
   return bindActionCreators(
     {
+      onSubmitOutcome: submitOutcome,
       onSelectIssue: selectIssueActionCreator,
-      onGetIssuesIfNeeded: getGroupIssuesIfNeeded,
-      onJoinGroup: joinGroupActionCreator,
+      onGetIssuesIfNeeded: () => {
+        return (nextDispatch: Dispatch<ApplicationState>,
+                getState: () => ApplicationState) => {
+          dispatch(getGroupIssuesIfNeeded(ownProps.match.params.groupid));
+        };
+      },
+      clearLocation: clearAddress,
     },
     dispatch);
 };
 
-export default connect<StateProps, DispatchProps, OwnProps>(mapStateToProps, mapDispatchToProps)(GroupPage);
+export default connect<StateProps, DispatchProps, OwnProps>(mapStateToProps, mapDispatchToProps)(CallPage);

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -7,7 +7,7 @@ import { formatNumber } from '../shared/utils';
 import { getGroup } from '../../services/apiServices';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
-import { queueUntilHydration } from '../../redux/rehydrationUtil';
+import { queueUntilRehydration } from '../../redux/rehydrationUtil';
 
 interface RouteProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 
@@ -26,7 +26,7 @@ interface Props extends RouteProps {
 }
 
 export interface State {
-  loaded: GroupLoadingState;
+  loadingState: GroupLoadingState;
   pageGroup?: Group;
 }
 
@@ -45,7 +45,7 @@ class GroupPage extends React.Component<Props, State> {
 
   setStateFromProps(props: Props): State {
     return {
-      loaded: GroupLoadingState.LOADING,
+      loadingState: GroupLoadingState.LOADING,
       pageGroup: undefined,
     };
   }
@@ -53,14 +53,14 @@ class GroupPage extends React.Component<Props, State> {
   componentWillReceiveProps(newProps: Props) {
     if (this.state.pageGroup) {
       if (newProps.match.params.groupid !== this.state.pageGroup.id) {
-        this.setState({ loaded: GroupLoadingState.LOADING });
+        this.setState({ loadingState: GroupLoadingState.LOADING });
         this.getGroupDetails(newProps.match.params.groupid);
       }      
     }
   }
 
   componentDidMount() {
-    queueUntilHydration(() => {
+    queueUntilRehydration(() => {
       this.getGroupDetails(this.props.match.params.groupid);
     });
   }
@@ -69,9 +69,9 @@ class GroupPage extends React.Component<Props, State> {
     getGroup(groupid).then((response: Group) => {      
       this.props.onGetIssuesIfNeeded(groupid);
 
-      this.setState({ loaded: GroupLoadingState.FOUND, pageGroup: response });
+      this.setState({ loadingState: GroupLoadingState.FOUND, pageGroup: response });
     }).catch((e) => {
-      this.setState({ loaded: GroupLoadingState.NOTFOUND });
+      this.setState({ loadingState: GroupLoadingState.NOTFOUND });
     });  
   }
 
@@ -84,7 +84,7 @@ class GroupPage extends React.Component<Props, State> {
   }
 
   render() {
-    switch (this.state.loaded) {
+    switch (this.state.loadingState) {
       case GroupLoadingState.LOADING:
         return (
           <LayoutContainer

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -50,16 +50,29 @@ class GroupPage extends React.Component<Props, State> {
     };
   }
 
+  componentWillReceiveProps(newProps: Props) {
+    if (this.state.pageGroup) {
+      if (newProps.match.params.groupid !== this.state.pageGroup.id) {
+        this.setState({ loaded: GroupLoadingState.LOADING });
+        this.getGroupDetails(newProps.match.params.groupid);
+      }      
+    }
+  }
+
   componentDidMount() {
     queueUntilHydration(() => {
-      getGroup(this.props.match.params.groupid).then((response: Group) => {      
-        this.props.onGetIssuesIfNeeded(this.props.match.params.groupid);
-  
-        this.setState({ loaded: GroupLoadingState.FOUND, pageGroup: response });
-      }).catch((e) => {
-        this.setState({ loaded: GroupLoadingState.NOTFOUND });
-      });  
+      this.getGroupDetails(this.props.match.params.groupid);
     });
+  }
+
+  getGroupDetails = (groupid: string) => {
+    getGroup(groupid).then((response: Group) => {      
+      this.props.onGetIssuesIfNeeded(groupid);
+
+      this.setState({ loaded: GroupLoadingState.FOUND, pageGroup: response });
+    }).catch((e) => {
+      this.setState({ loaded: GroupLoadingState.NOTFOUND });
+    });  
   }
 
   joinTeam = (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/components/groups/GroupPageContainer.tsx
+++ b/src/components/groups/GroupPageContainer.tsx
@@ -2,27 +2,35 @@ import { connect, Dispatch } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { ApplicationState } from '../../redux/root';
 import GroupPage from './GroupPage';
-import { Group } from '../../common/model';
-import { getIssuesIfNeeded } from '../../redux/remoteData';
+import { Group, Issue } from '../../common/model';
+import { getGroupIssuesIfNeeded } from '../../redux/remoteData';
+import { LocationState } from '../../redux/location/reducer';
+import { CallState } from '../../redux/callState/reducer';
 import { selectIssueActionCreator, joinGroupActionCreator } from '../../redux/callState';
 
 import { RouteComponentProps } from 'react-router-dom';
 
-interface OwnProps extends RouteComponentProps<{ id: string }> { }
+interface OwnProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 
 interface StateProps {
   readonly activeGroup?: Group;
+  readonly groupIssues: Issue[];
+  readonly callState: CallState;
+  readonly locationState: LocationState;
 }
 
 interface DispatchProps {
   readonly onSelectIssue: (issueId: string) => void;
-  readonly onGetIssuesIfNeeded: () => void;
+  readonly onGetIssuesIfNeeded: (groupid: string) => void;
   readonly onJoinGroup: (group: Group) => void;
 }
 
 const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProps => {
   return {
-    activeGroup: state.callState.group
+    activeGroup: state.callState.group,
+    groupIssues: state.remoteDataState.groupIssues,
+    callState: state.callState,
+    locationState: state.locationState,
   };
 };
 
@@ -30,7 +38,7 @@ const mapDispatchToProps = (dispatch: Dispatch<ApplicationState>): DispatchProps
   return bindActionCreators(
     {
       onSelectIssue: selectIssueActionCreator,
-      onGetIssuesIfNeeded: getIssuesIfNeeded,
+      onGetIssuesIfNeeded: getGroupIssuesIfNeeded,
       onJoinGroup: joinGroupActionCreator,
     },
     dispatch);

--- a/src/components/groups/index.ts
+++ b/src/components/groups/index.ts
@@ -1,6 +1,8 @@
 import GroupPageContainer from './GroupPageContainer';
+import GroupCallPageContainer from './GroupCallPageContainer';
 import GroupPage from './GroupPage';
 
 export {
-  GroupPageContainer, GroupPage
+  GroupPageContainer, GroupPage,
+  GroupCallPageContainer
 };

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -17,6 +17,8 @@ interface Props {
 export const IssuesList: React.StatelessComponent<Props> = (props: Props) => {
   let currentIssueId: string = props.currentIssue ? props.currentIssue.id : '';
 
+  // console.log("props",props.match.params.id)
+
   return (
     <ul className="issues-list" role="navigation">
       {props.issues && props.issues.map ? props.issues.map(issue =>

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -9,6 +9,7 @@ import { IssuesListItem } from './index';
 interface Props {
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
+  readonly currentGroup?: string;
   readonly completedIssueIds: string[];
   readonly t: TranslationFunction;
   readonly onSelectIssue: (issueId: string) => Function;
@@ -17,7 +18,22 @@ interface Props {
 export const IssuesList: React.StatelessComponent<Props> = (props: Props) => {
   let currentIssueId: string = props.currentIssue ? props.currentIssue.id : '';
 
-  // console.log("props",props.match.params.id)
+  const listFooter = () => {
+    if (!props.currentGroup) {
+      return (
+        <li>
+          <Link
+            to={`/more`}
+            className={`issues__footer-link`}
+          >
+            <span>{props.t('issues.viewAllActiveIssues')}</span>
+          </Link>
+        </li>
+      );
+    } else {
+      return <span />;
+    }
+  };
 
   return (
     <ul className="issues-list" role="navigation">
@@ -30,16 +46,10 @@ export const IssuesList: React.StatelessComponent<Props> = (props: Props) => {
             (find(props.completedIssueIds, (issueId: string) => issue.id === issueId) !== undefined)
           }
           isIssueActive={currentIssueId === issue.id}
+          currentGroup={props.currentGroup}
           onSelectIssue={props.onSelectIssue}
         />) : <div style={{ textAlign: 'center' }}>{props.t('noCalls.title')}</div>}
-      <li>
-        <Link
-          to={`/more`}
-          className={`issues__footer-link`}
-        >
-          <span>{props.t('issues.viewAllActiveIssues')}</span>
-        </Link>
-      </li>
+      {listFooter()}
     </ul>
   );
 };

--- a/src/components/issues/IssuesListItem.tsx
+++ b/src/components/issues/IssuesListItem.tsx
@@ -6,6 +6,7 @@ interface Props {
   readonly issue: Issue;
   readonly isIssueComplete: boolean;
   readonly isIssueActive: boolean;
+  readonly currentGroup?: string;
   readonly onSelectIssue: (issueId: string) => Function;
 }
 
@@ -15,12 +16,16 @@ export class IssuesListItem extends React.Component<Props, State> {
   render() {
     const isCompleted = this.props.isIssueComplete ? 'is-complete' : '';
     const isActive = this.props.isIssueActive ? 'is-active' : '';
+
+    // need to provide alternative links for on group page
+    const issueLink = this.props.currentGroup ?
+      `/group/${this.props.currentGroup}/${this.props.issue.id}` : `/issue/${this.props.issue.id}`;
     return (
       <li>
         <Link
           aria-controls="content"
           className={`issues-list__item ${isCompleted} ${isActive}`}
-          to={`/issue/${this.props.issue.id}`}
+          to={issueLink}
           onClick={() => this.props.onSelectIssue(this.props.issue.id)}
         >
           <span aria-live="polite" className={`issues-list__item__status ${isCompleted} ${isActive}`}>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DonationContainer } from '../donation/';
+// import { DonationContainer } from '../donation/';
 
 interface Props {}
 
@@ -7,7 +7,7 @@ export const Header: React.StatelessComponent<Props> = (props: Props) => {
 
   return (
     <header className="logo__header" role="banner" >
-      <DonationContainer />
+      {/* <DonationContainer /> */}
     </header>
   );
 };

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -10,6 +10,7 @@ interface Props {
   readonly issueId: string;
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
+  readonly currentGroup?: string;
   readonly completedIssueIds: string[];
   readonly callState: CallState;
   readonly locationState: LocationState;
@@ -33,6 +34,7 @@ const Layout: React.StatelessComponent<Props> = (props: Props) => (
           <Sidebar
             issues={props.issues}
             currentIssue={props.currentIssue ? props.currentIssue : undefined}
+            currentGroup={props.currentGroup}
             completedIssueIds={props.completedIssueIds}
             onSelectIssue={props.onSelectIssue}
           />

--- a/src/components/layout/LayoutContainer.tsx
+++ b/src/components/layout/LayoutContainer.tsx
@@ -11,6 +11,8 @@ import { Issue } from '../../common/model';
 
 interface OwnProps {
   readonly issueId?: string;
+  readonly issues?: Issue[];
+  readonly currentGroup?: string;
   readonly children?: {};
 }
 
@@ -18,6 +20,7 @@ interface StateProps {
   readonly children?: {};
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
+  readonly currentGroup?: string;
   readonly completedIssueIds: string[];
   readonly callState: CallState;
   readonly locationState: LocationState;
@@ -35,9 +38,14 @@ function mapStateToProps(state: ApplicationState, ownProps: OwnProps): StateProp
     currentIssue = find(state.remoteDataState.issues, i => i.id === ownProps.issueId);
   }
 
+  let issues: Issue[] = [];
+  // overrise issues from above the layout container if needed
+  issues = ownProps.issues ? ownProps.issues : state.remoteDataState.issues;
+
   return {
-    issues: state.remoteDataState.issues,
+    issues: issues,
     currentIssue: currentIssue,
+    currentGroup: ownProps.currentGroup,
     completedIssueIds: state.callState.completedIssueIds,
     callState: state.callState,
     locationState: state.locationState,

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -6,6 +6,7 @@ import { IssuesListTranslatable } from '../issues';
 interface Props {
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
+  readonly currentGroup?: string;
   readonly completedIssueIds: string[];
   readonly onSelectIssue: (issueId: string) => Function;
 }
@@ -15,6 +16,7 @@ const Sidebar: React.StatelessComponent<Props> = (props: Props) => {
     <IssuesListTranslatable
       issues={props.issues}
       currentIssue={props.currentIssue}
+      currentGroup={props.currentGroup}
       completedIssueIds={props.completedIssueIds}
       onSelectIssue={props.onSelectIssue}
       t={i18n.t}

--- a/src/components/shared/utils.test.ts
+++ b/src/components/shared/utils.test.ts
@@ -1,4 +1,6 @@
-import { formatLocationForBackEnd, formatNumber } from './utils';
+import { Issue, DefaultIssue } from './../../common/model';
+import { RemoteDataState } from '../../redux/remoteData';
+import { formatLocationForBackEnd, formatNumber, getIssue } from './utils';
 
 class Data {
   constructor(private pactual: string | number | null | undefined, private pexpected: string) {}
@@ -77,3 +79,54 @@ const formatNumberTester = (data: Data) => {
   const results = formatNumber(data.actual as number | string);
   expect(results).toEqual(data.expected);
 };
+
+test('if issueId arg is for an active issue, getIssue should return the current active issue', () => {
+  const id = '1';
+  let issue = Object.assign({}, DefaultIssue, {id, inactive: false});
+  let issues: Issue[] = [
+      issue
+  ];
+  let inactiveIssues: Issue[] = [
+    Object.assign({}, DefaultIssue, {id: '999', inactive: true})
+  ];
+  let state = Object.assign({}, {} as RemoteDataState, {issues, inactiveIssues});
+  let result: Issue = getIssue(state, id) as Issue;
+  expect(result.id).toBe(id);
+});
+
+test('if issueId arg is for an inactive issue, getIssue should return the current inactive issue', () => {
+  const id = 'inactive1';
+  let issue = Object.assign({}, DefaultIssue, {id: '1', inactive: false});
+  let issues: Issue[] = [
+      issue
+  ];
+  let inactiveIssues: Issue[] = [
+    Object.assign({}, DefaultIssue, {id, inactive: true})
+  ];
+  let state = Object.assign({}, {} as RemoteDataState, {issues, inactiveIssues});
+  let result: Issue = getIssue(state, id) as Issue;
+  expect(result.id).toBe(id);
+});
+
+test('if issueId arg is for an unknown issue, getIssue should return undefined', () => {
+  const id = 'unknown1111';
+  const activeId = 'active100';
+  let issue = Object.assign({}, DefaultIssue, {id: activeId, inactive: false});
+  let issues: Issue[] = [
+      issue
+  ];
+  const inactiveId = 'inactive101';
+  let inactiveIssues: Issue[] = [
+    Object.assign({}, DefaultIssue, {id: inactiveId, inactive: true})
+  ];
+  let state = Object.assign({}, {} as RemoteDataState, {issues, inactiveIssues});
+  let result = getIssue(state, id);
+  expect(result).toBeUndefined();
+});
+
+test('if remote data state has no active or inactive issues, getIssue should return undefined', () => {
+  const id = 'unknown1111';
+  let state = {} as RemoteDataState;
+  let result = getIssue(state, id);
+  expect(result).toBeUndefined();
+});

--- a/src/components/shared/utils.ts
+++ b/src/components/shared/utils.ts
@@ -1,6 +1,5 @@
 import * as Constants from '../../common/constants';
 import { ApplicationState } from '../../redux/root';
-import { Issue } from '../../common/model';
 
 import { find } from 'lodash';
 
@@ -59,19 +58,26 @@ export const formatNumber = (unformattedNumber: number | string) => {
 };
 
 export const getIssue = (state: ApplicationState, issueId: string) => {
-  let currentIssue: Issue | undefined = undefined;
-
   if (state.remoteDataState.issues) {
-    currentIssue = find(state.remoteDataState.issues, (i => i.id === issueId));
+    const currentActiveIssue = find(state.remoteDataState.issues, (i => i.id === issueId));
+    if (currentActiveIssue) {
+      return currentActiveIssue;
+    }
   }
 
   if (state.remoteDataState.inactiveIssues) {
-    currentIssue = find(state.remoteDataState.inactiveIssues, (i => i.id === issueId));    
+    const currentInactiveIssue = find(state.remoteDataState.inactiveIssues, (i => i.id === issueId));    
+    if (currentInactiveIssue) {
+      return currentInactiveIssue;
+    }
   }
 
   if (state.remoteDataState.groupIssues) {
-    currentIssue = find(state.remoteDataState.groupIssues, (i => i.id === issueId));    
+    const currentGroupIssue = find(state.remoteDataState.groupIssues, (i => i.id === issueId));
+    if (currentGroupIssue) {
+      return currentGroupIssue;
+    }
   }
   
-  return currentIssue;
+  return undefined;
 };

--- a/src/components/shared/utils.ts
+++ b/src/components/shared/utils.ts
@@ -61,10 +61,17 @@ export const formatNumber = (unformattedNumber: number | string) => {
 export const getIssue = (state: ApplicationState, issueId: string) => {
   let currentIssue: Issue | undefined = undefined;
 
-  if (state.remoteDataState.issues && state.remoteDataState.inactiveIssues) {
-    const allIssues = state.remoteDataState.issues.concat(state.remoteDataState.inactiveIssues);
-    currentIssue = find(allIssues, (i => i.id === issueId));
+  if (state.remoteDataState.issues) {
+    currentIssue = find(state.remoteDataState.issues, (i => i.id === issueId));
   }
 
+  if (state.remoteDataState.inactiveIssues) {
+    currentIssue = find(state.remoteDataState.inactiveIssues, (i => i.id === issueId));    
+  }
+
+  if (state.remoteDataState.groupIssues) {
+    currentIssue = find(state.remoteDataState.groupIssues, (i => i.id === issueId));    
+  }
+  
   return currentIssue;
 };

--- a/src/components/shared/utils.ts
+++ b/src/components/shared/utils.ts
@@ -1,5 +1,6 @@
 import * as Constants from '../../common/constants';
-import { ApplicationState } from '../../redux/root';
+import { Issue } from './../../common/model';
+import { RemoteDataState } from '../../redux/remoteData';
 
 import { find } from 'lodash';
 
@@ -57,27 +58,27 @@ export const formatNumber = (unformattedNumber: number | string) => {
   }
 };
 
-export const getIssue = (state: ApplicationState, issueId: string) => {
-  if (state.remoteDataState.issues) {
-    const currentActiveIssue = find(state.remoteDataState.issues, (i => i.id === issueId));
+export const getIssue = (remoteDataState: RemoteDataState, issueId: string): Issue | undefined => {
+  if (remoteDataState.issues) {
+    const currentActiveIssue = find(remoteDataState.issues, (i => i.id === issueId));
     if (currentActiveIssue) {
       return currentActiveIssue;
     }
   }
 
-  if (state.remoteDataState.inactiveIssues) {
-    const currentInactiveIssue = find(state.remoteDataState.inactiveIssues, (i => i.id === issueId));    
+  if (remoteDataState.inactiveIssues) {
+    const currentInactiveIssue = find(remoteDataState.inactiveIssues, (i => i.id === issueId));
     if (currentInactiveIssue) {
       return currentInactiveIssue;
     }
   }
 
-  if (state.remoteDataState.groupIssues) {
-    const currentGroupIssue = find(state.remoteDataState.groupIssues, (i => i.id === issueId));
+  if (remoteDataState.groupIssues) {
+    const currentGroupIssue = find(remoteDataState.groupIssues, (i => i.id === issueId));
     if (currentGroupIssue) {
       return currentGroupIssue;
     }
   }
-  
+
   return undefined;
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ import { DonePageContainer } from './components/done';
 import { MoreIssuesContainer } from './components/issues';
 import { CallPageContainer } from './components/call';
 import { MyImpactPageContainer } from './components/myimpact';
-import { GroupPageContainer } from './components/groups';
+import { GroupPageContainer, GroupCallPageContainer } from './components/groups';
 import './components/bundle.css';
 import './components/shared/scss/style.css';
 import './components/shared/scss/vendor/normalize.css';
@@ -62,7 +62,7 @@ ReactDOM.render(
           <Route path="/impact" exact={true} component={MyImpactPageContainer} />
           <Route path="/more" exact={true} component={MoreIssuesContainer} />
           <Route path="/group/:groupid" exact={true} component={GroupPageContainer} />
-          <Route path="/group/:groupid/:issueid" exact={true} component={GroupPageContainer} />
+          <Route path="/group/:groupid/:issueid" exact={true} component={GroupCallPageContainer} />
           <Route path="/faq" exact={true} component={FaqPage} />
           <Route path="/about" exact={true} component={AboutPage} />
           <Route path="*" component={HomePageContainer} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,7 +61,8 @@ ReactDOM.render(
           <Route path="/done/:id" exact={true} component={DonePageContainer} />
           <Route path="/impact" exact={true} component={MyImpactPageContainer} />
           <Route path="/more" exact={true} component={MoreIssuesContainer} />
-          <Route path="/group/:id" exact={true} component={GroupPageContainer} />
+          <Route path="/group/:groupid" exact={true} component={GroupPageContainer} />
+          <Route path="/group/:groupid/:issueid" exact={true} component={GroupPageContainer} />
           <Route path="/faq" exact={true} component={FaqPage} />
           <Route path="/about" exact={true} component={AboutPage} />
           <Route path="*" component={HomePageContainer} />

--- a/src/redux/rehydrationUtil.ts
+++ b/src/redux/rehydrationUtil.ts
@@ -1,6 +1,5 @@
 import { Dispatch } from 'redux';
 import { ApplicationState } from './root';
-import { startup } from './remoteData/asyncActionCreator';
 
 // when things are dispatched on component mount on first page load, 
 // it's possible that this can occur before rehydration is complete.
@@ -9,13 +8,10 @@ import { startup } from './remoteData/asyncActionCreator';
 let hasRehydrated = false;
 let rehydrationQueue: Function[] = [];
 
-export const rehydrated = () => {
+export const onStorageRehydrated = () => {
   return (dispatch: Dispatch<ApplicationState>,
           getState: () => ApplicationState) => {
     // console.log(`rehydrated, executing`);
-
-    // startup should always be run first after rehydration is complete
-    startup(dispatch, getState);
 
     hasRehydrated = true;
     
@@ -27,7 +23,7 @@ export const rehydrated = () => {
   };
 };
 
-export const queueUntilHydration = (f: Function) => {
+export const queueUntilRehydration = (f: Function) => {
   if (hasRehydrated) {
     // console.log(`already rehydrated, executing`);
     f();

--- a/src/redux/rehydrationUtil.ts
+++ b/src/redux/rehydrationUtil.ts
@@ -12,7 +12,7 @@ let rehydrationQueue: Function[] = [];
 export const rehydrated = () => {
   return (dispatch: Dispatch<ApplicationState>,
           getState: () => ApplicationState) => {
-    console.log(`rehydrated, executing`);
+    // console.log(`rehydrated, executing`);
 
     // startup should always be run first after rehydration is complete
     startup(dispatch, getState);
@@ -29,10 +29,10 @@ export const rehydrated = () => {
 
 export const queueUntilHydration = (f: Function) => {
   if (hasRehydrated) {
-    console.log(`already rehydrated, executing`);
+    // console.log(`already rehydrated, executing`);
     f();
   } else {
-    console.log(`storing for later`);
+    // console.log(`storing for later`);
     rehydrationQueue.push(f);
   }
 };

--- a/src/redux/rehydrationUtil.ts
+++ b/src/redux/rehydrationUtil.ts
@@ -1,0 +1,38 @@
+import { Dispatch } from 'redux';
+import { ApplicationState } from './root';
+import { startup } from './remoteData/asyncActionCreator';
+
+// when things are dispatched on component mount on first page load, 
+// it's possible that this can occur before rehydration is complete.
+// keep track of this and launch any post-hydration actions afterwards
+
+let hasRehydrated = false;
+let rehydrationQueue: Function[] = [];
+
+export const rehydrated = () => {
+  return (dispatch: Dispatch<ApplicationState>,
+          getState: () => ApplicationState) => {
+    console.log(`rehydrated, executing`);
+
+    // startup should always be run first after rehydration is complete
+    startup(dispatch, getState);
+
+    hasRehydrated = true;
+    
+    for (let f of rehydrationQueue) {
+      f();
+    }
+  
+    rehydrationQueue = [];
+  };
+};
+
+export const queueUntilHydration = (f: Function) => {
+  if (hasRehydrated) {
+    console.log(`already rehydrated, executing`);
+    f();
+  } else {
+    console.log(`storing for later`);
+    rehydrationQueue.push(f);
+  }
+};

--- a/src/redux/remoteData/action.ts
+++ b/src/redux/remoteData/action.ts
@@ -4,6 +4,7 @@ import { Issue, Donations } from '../../common/model';
 
 export enum RemoteDataActionType {
   GET_ISSUES = 'GET_ISSUES',
+  GET_GROUP_ISSUES = 'GET_GROUP_ISSUES',
   GET_CALL_TOTAL = 'GET_CALL_TOTAL',
   GET_DONATIONS = 'GET_DONATIONS',
   API_ERROR = 'API_ERROR'
@@ -16,6 +17,11 @@ export interface RemoteDataAction extends  Action {
 
 export interface IssuesAction extends RemoteDataAction {
   type: RemoteDataActionType.GET_ISSUES;
+  payload: Issue[];
+}
+
+export interface GroupIssuesAction extends RemoteDataAction {
+  type: RemoteDataActionType.GET_GROUP_ISSUES;
   payload: Issue[];
 }
 

--- a/src/redux/remoteData/actionCreator.ts
+++ b/src/redux/remoteData/actionCreator.ts
@@ -1,12 +1,19 @@
 import { DonationsAction } from './action';
 import { Donations } from './../../common/model';
 import { NewLocationLookupAction, LocationActionType } from './../location/index';
-import { CallCountAction, ApiErrorAction, IssuesAction, RemoteDataActionType } from './index';
+import { CallCountAction, ApiErrorAction, IssuesAction, GroupIssuesAction, RemoteDataActionType } from './index';
 import { Issue } from '../../common/model';
 
 export const issuesActionCreator = (issues: Issue[]): IssuesAction => {
   return {
     type: RemoteDataActionType.GET_ISSUES,
+    payload: issues
+  };
+};
+
+export const groupIssuesActionCreator = (issues: Issue[]): GroupIssuesAction => {
+  return {
+    type: RemoteDataActionType.GET_GROUP_ISSUES,
     payload: issues
   };
 };

--- a/src/redux/remoteData/asyncActionCreator.ts
+++ b/src/redux/remoteData/asyncActionCreator.ts
@@ -46,7 +46,6 @@ export const getGroupIssuesIfNeeded = (groupid: string) => {
     // directly to a route with an issue id
     if (!state.remoteDataState.groupIssues || state.remoteDataState.groupIssues.length === 0 ||
         state.remoteDataState.currentGroup !== groupid) {
-      console.log(`starting group issue fetching`);
         
       const loc = state.locationState.address;
       if (loc) {
@@ -88,7 +87,6 @@ export const fetchAllIssues = (address: string = '') => {
 export const fetchGroupIssues = (groupid: string, address: string = '') => {
   return (dispatch: Dispatch<ApplicationState>,
           getState: () => ApplicationState) => {
-    console.log(`fetching group issues`, groupid);
     return getGroupIssues(groupid, address)
       .then((response: GroupIssues) => {
         if (response.invalidAddress) {
@@ -101,7 +99,6 @@ export const fetchGroupIssues = (groupid: string, address: string = '') => {
           if (!address) {
             dispatch(setUiState(LocationUiState.LOCATION_ERROR));
           }
-          console.log(`got issues`, response.issues);
           dispatch(setSplitDistrict(response.splitDistrict));
           dispatch(setLocationFetchType(LocationFetchType.CACHED_ADDRESS));
           dispatch(groupIssuesActionCreator(response.issues));
@@ -206,7 +203,6 @@ export const fetchBrowserGeolocation = () => {
 
 export const startup = (dispatch: Dispatch<ApplicationState>,
                         getState: () => ApplicationState) => {
-  console.log(`startup`);
   // dispatch donations
   dispatch(fetchDonations());
   dispatch(setUiState(LocationUiState.FETCHING_LOCATION));

--- a/src/redux/remoteData/asyncActionCreator.ts
+++ b/src/redux/remoteData/asyncActionCreator.ts
@@ -201,28 +201,30 @@ export const fetchBrowserGeolocation = () => {
   };
 };
 
-export const startup = (dispatch: Dispatch<ApplicationState>,
-                        getState: () => ApplicationState) => {
-  // dispatch donations
-  dispatch(fetchDonations());
-  dispatch(setUiState(LocationUiState.FETCHING_LOCATION));
-  const state = getState();
-  // clear contact indexes loaded from local storage
-  dispatch(clearContactIndexes());
-  // add completed issues from Choo app in localStorage to
-  // this apps callState.completedIssueIds
-  migrateLegacyCompletedIssues(dispatch);
-  const loc = state.locationState.address;
-  if (loc) {
-    // console.log('Using cached address');
-    dispatch(fetchAllIssues(loc))
-      .then(() => {
-        setLocationFetchType(LocationFetchType.CACHED_ADDRESS);
-      });
-  } else {
-    dispatch(fetchBrowserGeolocation());
-  }
-  dispatch(fetchCallCount());
+export const startup = () => {
+  return (dispatch: Dispatch<ApplicationState>,
+          getState: () => ApplicationState) => {
+    // dispatch donations
+    dispatch(fetchDonations());
+    dispatch(setUiState(LocationUiState.FETCHING_LOCATION));
+    const state = getState();
+    // clear contact indexes loaded from local storage
+    dispatch(clearContactIndexes());
+    // add completed issues from Choo app in localStorage to
+    // this apps callState.completedIssueIds
+    migrateLegacyCompletedIssues(dispatch);
+    const loc = state.locationState.address;
+    if (loc) {
+      // console.log('Using cached address');
+      dispatch(fetchAllIssues(loc))
+        .then(() => {
+          setLocationFetchType(LocationFetchType.CACHED_ADDRESS);
+        });
+    } else {
+      dispatch(fetchBrowserGeolocation());
+    }
+    dispatch(fetchCallCount());
+  };
 };
 
 const migrateLegacyCompletedIssues = (dispatch: Dispatch<ApplicationState>) => {

--- a/src/redux/remoteData/index.ts
+++ b/src/redux/remoteData/index.ts
@@ -1,7 +1,7 @@
-export { IssuesAction, RemoteDataAction, RemoteDataActionType,
+export { IssuesAction, GroupIssuesAction, RemoteDataAction, RemoteDataActionType,
   CallCountAction, ApiErrorAction, DonationsAction } from './action';
-export { issuesActionCreator, callCountActionCreator,
+export { issuesActionCreator, groupIssuesActionCreator, callCountActionCreator,
   apiErrorMessageActionCreator, donationsActionCreator } from './actionCreator';
 export { RemoteDataState, remoteDataReducer } from './reducer';
-export { startup, fetchAllIssues, getIssuesIfNeeded,
+export { fetchAllIssues, getIssuesIfNeeded, getGroupIssuesIfNeeded,
    fetchCallCount, fetchLocationByIP, fetchBrowserGeolocation } from './asyncActionCreator';

--- a/src/redux/remoteData/index.ts
+++ b/src/redux/remoteData/index.ts
@@ -3,5 +3,5 @@ export { IssuesAction, GroupIssuesAction, RemoteDataAction, RemoteDataActionType
 export { issuesActionCreator, groupIssuesActionCreator, callCountActionCreator,
   apiErrorMessageActionCreator, donationsActionCreator } from './actionCreator';
 export { RemoteDataState, remoteDataReducer } from './reducer';
-export { fetchAllIssues, getIssuesIfNeeded, getGroupIssuesIfNeeded,
+export { startup, fetchAllIssues, getIssuesIfNeeded, getGroupIssuesIfNeeded,
    fetchCallCount, fetchLocationByIP, fetchBrowserGeolocation } from './asyncActionCreator';

--- a/src/redux/remoteData/reducer.ts
+++ b/src/redux/remoteData/reducer.ts
@@ -29,7 +29,6 @@ export const remoteDataReducer: Reducer<RemoteDataState> = (
       const issuesState = Object.assign({}, state, {issues: activeIssues, inactiveIssues: inactiveIssues});
       return issuesState;
     case RemoteDataActionType.GET_GROUP_ISSUES:
-      console.log("got some group issues",action.payload);
       return Object.assign({}, state, {groupIssues: action.payload});
     case RemoteDataActionType.GET_CALL_TOTAL:
       return Object.assign({}, state, {callTotal: action.payload});

--- a/src/redux/remoteData/reducer.ts
+++ b/src/redux/remoteData/reducer.ts
@@ -5,6 +5,8 @@ import { RemoteDataAction, RemoteDataActionType } from './index';
 export interface RemoteDataState {
   issues: Issue[];
   inactiveIssues: Issue[];
+  currentGroup: string;
+  groupIssues: Issue[];
   callTotal: number;
   donations: Donations;
   errorMessage: string;
@@ -26,6 +28,9 @@ export const remoteDataReducer: Reducer<RemoteDataState> = (
 
       const issuesState = Object.assign({}, state, {issues: activeIssues, inactiveIssues: inactiveIssues});
       return issuesState;
+    case RemoteDataActionType.GET_GROUP_ISSUES:
+      console.log("got some group issues",action.payload);
+      return Object.assign({}, state, {groupIssues: action.payload});
     case RemoteDataActionType.GET_CALL_TOTAL:
       return Object.assign({}, state, {callTotal: action.payload});
     case RemoteDataActionType.GET_DONATIONS:

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -4,8 +4,8 @@ import rootReducer from './root';
 // import { createLogger, ReduxLoggerOptions } from 'redux-logger';
 import thunk from 'redux-thunk';
 import { ApplicationStateKeyType, ApplicationStateKey } from '../redux/root';
-// import { startup } from './remoteData';
-import { rehydrated } from './rehydrationUtil';
+import { startup } from './remoteData';
+import { onStorageRehydrated } from './rehydrationUtil';
 
 // declare var process: { env: { NODE_ENV: string } };
 // const env = process.env.NODE_ENV;
@@ -46,7 +46,10 @@ export default (initialState) => {
   persistor = persistStore(
     store,
     { whitelist: localPersistKeys },
-    () => store.dispatch(rehydrated())
+    () => {
+      store.dispatch(startup());
+      store.dispatch(onStorageRehydrated());
+    }
   );
 
   return store;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -4,7 +4,8 @@ import rootReducer from './root';
 // import { createLogger, ReduxLoggerOptions } from 'redux-logger';
 import thunk from 'redux-thunk';
 import { ApplicationStateKeyType, ApplicationStateKey } from '../redux/root';
-import { startup } from './remoteData';
+// import { startup } from './remoteData';
+import { rehydrated } from './rehydrationUtil';
 
 // declare var process: { env: { NODE_ENV: string } };
 // const env = process.env.NODE_ENV;
@@ -45,7 +46,7 @@ export default (initialState) => {
   persistor = persistStore(
     store,
     { whitelist: localPersistKeys },
-    () => store.dispatch(startup())
+    () => store.dispatch(rehydrated())
   );
 
   return store;

--- a/src/services/apiServices.ts
+++ b/src/services/apiServices.ts
@@ -1,11 +1,17 @@
 import { OutcomeData } from './../redux/callState/asyncActionCreator';
 import axios from 'axios';
 import * as querystring from 'querystring';
-import { ApiData, CountData, DonationGoal, Group } from './../common/model';
+import { ApiData, CountData, DonationGoal, Group, GroupIssues } from './../common/model';
 import * as Constants from '../common/constants';
 
 export const getAllIssues = (address: string): Promise<ApiData> => {
   return axios.get(`${Constants.ISSUES_API_URL}${encodeURIComponent(address)}`)
+    .then(response => Promise.resolve(response.data))
+    .catch(e => Promise.reject(e));
+};
+
+export const getGroupIssues = (groupid: string, address: string): Promise<GroupIssues> => {
+  return axios.get(`${Constants.GROUP_API_URL}/${groupid}/issues?address=${encodeURIComponent(address)}`)
     .then(response => Promise.resolve(response.data))
     .catch(e => Promise.reject(e));
 };


### PR DESCRIPTION
A couple notable changes here:

* introduction of `queueUntilHydration` which waits until we're rehydrated before doing tasks that are added to early-running things like `componentDidMount`
* a new endpoint for issues for groups, which slowly moves us away from airtable and onto real databases
* supporting group and normal issue pages in a single call page
* refactoring out an extra `splitDistrict` from call pages

I actually did this more than once because I had to figure out how a bunch of stuff really worked for react/redux. Every time I started composing an email to one of you with my problems @cdoremus or @schraj, I ended up coming up with something else to try which ended up being correct-ish. Fun!

You should be able to test this at `/group/nick`